### PR TITLE
docs: construct nested document line by line

### DIFF
--- a/docs/fundamentals/document/construct.md
+++ b/docs/fundamentals/document/construct.md
@@ -96,13 +96,10 @@ Document can be nested inside `.chunks` and `.matches`. The nested structure can
 from docarray import Document
 
 d = Document(id='d0')
-chunk = Document(id='d1')
-chunk_of_chunk = Document(id='d2')
-d.chunks.append(chunk)
-d.chunks[0].chunks.append(chunk_of_chunk)
+d.chunks.append(Document(id='d1'))
+d.chunks[0].chunks.append(Document(id='d2'))
 
-match = Document(id='d3')
-d.matches.append(match)
+d.matches.append(Document(id='d3'))
 
 print(d)
 ```

--- a/docs/fundamentals/document/construct.md
+++ b/docs/fundamentals/document/construct.md
@@ -100,6 +100,7 @@ d.chunks.append(Document(id='d1'))
 d.chunks[0].chunks.append(Document(id='d2'))
 
 d.matches.append(Document(id='d3'))
+d.matches[0].matches.append(Document(id='d4'))
 
 print(d)
 ```

--- a/docs/fundamentals/document/construct.md
+++ b/docs/fundamentals/document/construct.md
@@ -95,11 +95,14 @@ Document can be nested inside `.chunks` and `.matches`. The nested structure can
 ```python
 from docarray import Document
 
-d = Document(
-    id='d0',
-    chunks=[Document(id='d1', chunks=Document(id='d2'))],
-    matches=[Document(id='d3')],
-)
+d = Document(id='d0')
+chunk = Document(id='d1')
+chunk_of_chunk = Document(id='d2')
+d.chunks.append(chunk)
+d.chunks[0].chunks.append(chunk_of_chunk)
+
+match = Document(id='d3')
+d.matches.append(match)
 
 print(d)
 ```


### PR DESCRIPTION
create nested documents with one-liner could break the `granularity`, the recommended way: 
![89D97911-CB46-4D27-81BB-2A135BEE0CC8](https://user-images.githubusercontent.com/9794489/148803920-37c78c84-40db-4e5b-8fa8-115e691761c2.png)
