### PR TITLE
fix: improve mesh data loading

### DIFF
--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -22,18 +22,17 @@ class MeshDataMixin:
         """
         import trimesh
 
-        mesh = trimesh.load_mesh(self.uri).deduplicated()
-
-        pcs = []
-        for geo in mesh.geometry.values():
-            geo: trimesh.Trimesh
-            pcs.append(geo.sample(samples))
-
         if as_chunks:
             from .. import Document
 
-            for p in pcs:
-                self.chunks.append(Document(blob=p))
+            # try to coerce everything into a scene
+            scene = trimesh.load(self.uri, force='scene')
+            for geo in scene.geometry.values():
+                geo: trimesh.Trimesh
+                self.chunks.append(Document(blob=geo.sample(samples)))
         else:
-            self.blob = np.stack(pcs).squeeze()
+            # combine a scene into a single mesh
+            mesh = trimesh.load(self.uri, force='mesh')
+            self.blob = mesh.sample(samples)
+
         return self

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -234,3 +234,7 @@ def test_glb_converters():
     doc = Document(uri=os.path.join(cur_dir, 'toydata/test.glb'))
     doc.load_uri_to_point_cloud_blob(2000)
     assert doc.blob.shape == (2000, 3)
+
+    doc.load_uri_to_point_cloud_blob(2000, as_chunks=True)
+    assert len(doc.chunks) == 1
+    assert doc.chunks[0].blob.shape == (2000, 3)


### PR DESCRIPTION
`deduplicated()` would throw **divide by zero** error in some cases.