### PR TITLE
fix(pickle): hard code default pickle protocol

### DIFF
--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -4,7 +4,13 @@ import pickle
 from contextlib import nullcontext
 from typing import Union, BinaryIO, TYPE_CHECKING, Type, Optional
 
-from ....helper import random_uuid, __windows__, get_compress_ctx, decompress_bytes
+from ....helper import (
+    random_uuid,
+    __windows__,
+    __default_pickle_protocol__,
+    get_compress_ctx,
+    decompress_bytes,
+)
 
 if TYPE_CHECKING:
     from ....types import T
@@ -57,7 +63,7 @@ class BinaryIOMixin:
 
                 return cls.from_protobuf(dap)
             elif protocol == 'pickle-array':
-                return pickle.loads(d)
+                return pickle.loads(d, protocol=__default_pickle_protocol__)
             else:
                 _len = len(random_uuid().bytes)
                 _binary_delimiter = d[:_len]  # first get delimiter
@@ -144,7 +150,7 @@ class BinaryIOMixin:
                 if protocol == 'protobuf-array':
                     f.write(self.to_protobuf().SerializePartialToString())
                 elif protocol == 'pickle-array':
-                    f.write(pickle.dumps(self))
+                    f.write(pickle.dumps(self, protocol=__default_pickle_protocol__))
                 else:
                     if _show_progress:
                         from rich.progress import track as _track

--- a/docarray/document/mixins/porting.py
+++ b/docarray/document/mixins/porting.py
@@ -2,7 +2,7 @@ import dataclasses
 import pickle
 from typing import Optional, TYPE_CHECKING, Type, Dict, Any
 
-from ...helper import compress_bytes, decompress_bytes
+from ...helper import compress_bytes, decompress_bytes, __default_pickle_protocol__
 
 if TYPE_CHECKING:
     from ...types import T
@@ -42,7 +42,7 @@ class PortingMixin:
         self, protocol: str = 'pickle', compress: Optional[str] = None
     ) -> bytes:
         if protocol == 'pickle':
-            bstr = pickle.dumps(self)
+            bstr = pickle.dumps(self, protocol=__default_pickle_protocol__)
         elif protocol == 'protobuf':
             bstr = self.to_protobuf().SerializePartialToString()
         else:
@@ -67,7 +67,7 @@ class PortingMixin:
         """
         bstr = decompress_bytes(data, algorithm=compress)
         if protocol == 'pickle':
-            d = pickle.loads(bstr)
+            d = pickle.loads(bstr, protocol=__default_pickle_protocol__)
         elif protocol == 'protobuf':
             from ...proto.docarray_pb2 import DocumentProto
 

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -14,6 +14,8 @@ __resources_path__ = os.path.join(
     'resources',
 )
 
+__default_pickle_protocol__ = 4
+
 
 def typename(obj):
     """
@@ -294,15 +296,19 @@ def decompress_bytes(data: bytes, algorithm: Optional[str] = None) -> bytes:
 def get_compress_ctx(algorithm: Optional[str] = None, mode: str = 'wb'):
     if algorithm == 'lz4':
         import lz4.frame
+
         compress_ctx = lambda x: lz4.frame.LZ4FrameFile(x, mode)
     elif algorithm == 'gzip':
         import gzip
+
         compress_ctx = lambda x: gzip.GzipFile(fileobj=x, mode=mode)
     elif algorithm == 'bz2':
         import bz2
+
         compress_ctx = lambda x: bz2.BZ2File(x, mode)
     elif algorithm == 'lzma':
         import lzma
+
         compress_ctx = lambda x: lzma.LZMAFile(x, mode)
     else:
         compress_ctx = None


### PR DESCRIPTION
From https://docs.python.org/3/library/pickle.html#pickle.DEFAULT_PROTOCOL

> An integer, the default protocol version used for pickling. May be less than HIGHEST_PROTOCOL. Currently the default protocol is 4, first introduced in Python 3.4 and incompatible with previous versions.
> 
> Changed in version 3.0: The default protocol is 3.
> 
> Changed in version 3.8: The default protocol is 4.

After py3.8, the default pickle protocol is changed from 3 to 4. To archive the serialization compatible, the default protocol is hard coded in this PR. 