### PR TITLE
fix(array): fix getting docs by two ids

### DIFF
--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -146,11 +146,15 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 and len(index) == 2
                 and isinstance(index[0], (slice, Sequence))
             ):
+
+                # edge case where 2 ids are passed
+                if isinstance(index[0], str) and index[0] in self._id2offset:
+                    return DocumentArray(self._data[self._id2offset[t]] for t in index)
+
                 _docs = self[index[0]]
                 _attrs = index[1]
                 if isinstance(_attrs, str):
                     _attrs = (index[1],)
-
                 return _docs._get_attributes(*_attrs)
             elif isinstance(index[0], bool):
                 return DocumentArray(itertools.compress(self._data, index))

--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -146,9 +146,12 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 and len(index) == 2
                 and isinstance(index[0], (slice, Sequence))
             ):
-                # edge case where 2 ids are passed
-                if isinstance(index[0], str) and index[0] in self._id2offset:
+                # edge case where ids are passed as element selector
+                if isinstance(index[0], str) and all(
+                    i in self._id2offset for i in index
+                ):
                     return DocumentArray(self._data[self._id2offset[t]] for t in index)
+
                 _docs = self[index[0]]
                 _attrs = index[1]
                 if isinstance(_attrs, str):

--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 class DocumentArray(AllMixins, MutableSequence[Document]):
     def __init__(
-        self, docs: Optional['DocumentArraySourceType'] = None, copy: bool = False
+        self, docs: Optional["DocumentArraySourceType"] = None, copy: bool = False
     ):
         super().__init__()
         self._data = []
@@ -64,7 +64,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
 
         :return: a Python dict.
         """
-        if not hasattr(self, '_id_to_index'):
+        if not hasattr(self, "_id_to_index"):
             self._rebuild_id2offset()
         return self._id_to_index
 
@@ -78,7 +78,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             d.id: i for i, d in enumerate(self._data)
         }  # type: Dict[str, int]
 
-    def insert(self, index: int, value: 'Document'):
+    def insert(self, index: int, value: "Document"):
         """Insert `doc` at `index`.
 
         :param index: Position of the insertion.
@@ -97,10 +97,10 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
     def __len__(self):
         return len(self._data)
 
-    def __iter__(self) -> Iterator['Document']:
+    def __iter__(self) -> Iterator["Document"]:
         yield from self._data
 
-    def __contains__(self, x: Union[str, 'Document']):
+    def __contains__(self, x: Union[str, "Document"]):
         if isinstance(x, str):
             return x in self._id2offset
         elif isinstance(x, Document):
@@ -109,30 +109,30 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             return False
 
     @overload
-    def __getitem__(self, index: 'DocumentArraySingletonIndexType') -> 'Document':
+    def __getitem__(self, index: "DocumentArraySingletonIndexType") -> "Document":
         ...
 
     @overload
-    def __getitem__(self, index: 'DocumentArrayMultipleIndexType') -> 'DocumentArray':
+    def __getitem__(self, index: "DocumentArrayMultipleIndexType") -> "DocumentArray":
         ...
 
     @overload
-    def __getitem__(self, index: 'DocumentArraySingleAttributeType') -> List[Any]:
+    def __getitem__(self, index: "DocumentArraySingleAttributeType") -> List[Any]:
         ...
 
     @overload
     def __getitem__(
-        self, index: 'DocumentArrayMultipleAttributeType'
+        self, index: "DocumentArrayMultipleAttributeType"
     ) -> List[List[Any]]:
         ...
 
     def __getitem__(
-        self, index: 'DocumentArrayIndexType'
-    ) -> Union['Document', 'DocumentArray']:
+        self, index: "DocumentArrayIndexType"
+    ) -> Union["Document", "DocumentArray"]:
         if isinstance(index, (int, np.generic)) and not isinstance(index, bool):
             return self._data[int(index)]
         elif isinstance(index, str):
-            if index.startswith('@'):
+            if index.startswith("@"):
                 return self.traverse_flat(index[1:])
             else:
                 return self._data[self._id2offset[index]]
@@ -146,11 +146,9 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 and len(index) == 2
                 and isinstance(index[0], (slice, Sequence))
             ):
-
                 # edge case where 2 ids are passed
                 if isinstance(index[0], str) and index[0] in self._id2offset:
                     return DocumentArray(self._data[self._id2offset[t]] for t in index)
-
                 _docs = self[index[0]]
                 _attrs = index[1]
                 if isinstance(_attrs, str):
@@ -168,53 +166,53 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 return self[index.tolist()]
             else:
                 raise IndexError(
-                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
+                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
                 )
-        raise IndexError(f'Unsupported index type {typename(index)}: {index}')
+        raise IndexError(f"Unsupported index type {typename(index)}: {index}")
 
     @overload
     def __setitem__(
         self,
-        index: 'DocumentArrayMultipleAttributeType',
-        value: List[List['Any']],
+        index: "DocumentArrayMultipleAttributeType",
+        value: List[List["Any"]],
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: 'DocumentArraySingleAttributeType',
-        value: List['Any'],
+        index: "DocumentArraySingleAttributeType",
+        value: List["Any"],
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: 'DocumentArraySingletonIndexType',
-        value: 'Document',
+        index: "DocumentArraySingletonIndexType",
+        value: "Document",
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: 'DocumentArrayMultipleIndexType',
-        value: Sequence['Document'],
+        index: "DocumentArrayMultipleIndexType",
+        value: Sequence["Document"],
     ):
         ...
 
     def __setitem__(
         self,
-        index: 'DocumentArrayIndexType',
-        value: Union['Document', Sequence['Document']],
+        index: "DocumentArrayIndexType",
+        value: Union["Document", Sequence["Document"]],
     ):
         if isinstance(index, (int, np.generic)):
             index = int(index)
             self._data[index] = value
             self._id2offset[value.id] = index
         elif isinstance(index, str):
-            if index.startswith('@'):
+            if index.startswith("@"):
                 for _d, _v in zip(self.traverse_flat(index[1:]), value):
                     _d._data = _v._data
                 self._rebuild_id2offset()
@@ -253,9 +251,9 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                     value = (value,)
 
                 for _a, _v in zip(_attrs, value):
-                    if _a == 'blob':
+                    if _a == "blob":
                         _docs.blobs = _v
-                    elif _a == 'embedding':
+                    elif _a == "embedding":
                         _docs.embeddings = _v
                     else:
                         for _d, _vv in zip(_docs, _v):
@@ -263,8 +261,8 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             elif isinstance(index[0], bool):
                 if len(index) != len(self._data):
                     raise IndexError(
-                        f'Boolean mask index is required to have the same length as {len(self._data)}, '
-                        f'but receiving {len(index)}'
+                        f"Boolean mask index is required to have the same length as {len(self._data)}, "
+                        f"but receiving {len(index)}"
                     )
                 _selected = itertools.compress(self._data, index)
                 for _idx, _val in zip(_selected, value):
@@ -272,8 +270,8 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             elif isinstance(index[0], (int, str)):
                 if not isinstance(value, Sequence) or len(index) != len(value):
                     raise ValueError(
-                        f'Number of elements for assigning must be '
-                        f'the same as the index length: {len(index)}'
+                        f"Number of elements for assigning must be "
+                        f"the same as the index length: {len(index)}"
                     )
                 if isinstance(value, Document):
                     for si in index:
@@ -287,20 +285,20 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 self[index.tolist()] = value
             else:
                 raise IndexError(
-                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
+                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
                 )
         else:
-            raise IndexError(f'Unsupported index type {typename(index)}: {index}')
+            raise IndexError(f"Unsupported index type {typename(index)}: {index}")
 
-    def __delitem__(self, index: 'DocumentArrayIndexType'):
+    def __delitem__(self, index: "DocumentArrayIndexType"):
         if isinstance(index, (int, np.generic)):
             index = int(index)
             self._id2offset.pop(self._data[index].id)
             del self._data[index]
         elif isinstance(index, str):
-            if index.startswith('@'):
+            if index.startswith("@"):
                 raise NotImplementedError(
-                    'Delete elements along traversal paths is not implemented'
+                    "Delete elements along traversal paths is not implemented"
                 )
             else:
                 del self._data[self._id2offset[index]]
@@ -340,10 +338,10 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 del self[index.tolist()]
             else:
                 raise IndexError(
-                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
+                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
                 )
         else:
-            raise IndexError(f'Unsupported index type {typename(index)}: {index}')
+            raise IndexError(f"Unsupported index type {typename(index)}: {index}")
 
     def clear(self):
         """Clear the data of :class:`DocumentArray`"""
@@ -358,9 +356,9 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
         return len(self) > 0
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} (length={len(self)}) at {id(self)}>'
+        return f"<{self.__class__.__name__} (length={len(self)}) at {id(self)}>"
 
-    def __add__(self, other: 'Document'):
+    def __add__(self, other: "Document"):
         v = type(self)()
         for doc in self:
             v.append(doc)
@@ -368,6 +366,6 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             v.append(doc)
         return v
 
-    def extend(self, values: Iterable['Document']) -> None:
+    def extend(self, values: Iterable["Document"]) -> None:
         self._data.extend(values)
         self._rebuild_id2offset()

--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 class DocumentArray(AllMixins, MutableSequence[Document]):
     def __init__(
-        self, docs: Optional["DocumentArraySourceType"] = None, copy: bool = False
+        self, docs: Optional['DocumentArraySourceType'] = None, copy: bool = False
     ):
         super().__init__()
         self._data = []
@@ -64,7 +64,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
 
         :return: a Python dict.
         """
-        if not hasattr(self, "_id_to_index"):
+        if not hasattr(self, '_id_to_index'):
             self._rebuild_id2offset()
         return self._id_to_index
 
@@ -78,7 +78,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             d.id: i for i, d in enumerate(self._data)
         }  # type: Dict[str, int]
 
-    def insert(self, index: int, value: "Document"):
+    def insert(self, index: int, value: 'Document'):
         """Insert `doc` at `index`.
 
         :param index: Position of the insertion.
@@ -97,10 +97,10 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
     def __len__(self):
         return len(self._data)
 
-    def __iter__(self) -> Iterator["Document"]:
+    def __iter__(self) -> Iterator['Document']:
         yield from self._data
 
-    def __contains__(self, x: Union[str, "Document"]):
+    def __contains__(self, x: Union[str, 'Document']):
         if isinstance(x, str):
             return x in self._id2offset
         elif isinstance(x, Document):
@@ -109,30 +109,30 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             return False
 
     @overload
-    def __getitem__(self, index: "DocumentArraySingletonIndexType") -> "Document":
+    def __getitem__(self, index: 'DocumentArraySingletonIndexType') -> 'Document':
         ...
 
     @overload
-    def __getitem__(self, index: "DocumentArrayMultipleIndexType") -> "DocumentArray":
+    def __getitem__(self, index: 'DocumentArrayMultipleIndexType') -> 'DocumentArray':
         ...
 
     @overload
-    def __getitem__(self, index: "DocumentArraySingleAttributeType") -> List[Any]:
+    def __getitem__(self, index: 'DocumentArraySingleAttributeType') -> List[Any]:
         ...
 
     @overload
     def __getitem__(
-        self, index: "DocumentArrayMultipleAttributeType"
+        self, index: 'DocumentArrayMultipleAttributeType'
     ) -> List[List[Any]]:
         ...
 
     def __getitem__(
-        self, index: "DocumentArrayIndexType"
-    ) -> Union["Document", "DocumentArray"]:
+        self, index: 'DocumentArrayIndexType'
+    ) -> Union['Document', 'DocumentArray']:
         if isinstance(index, (int, np.generic)) and not isinstance(index, bool):
             return self._data[int(index)]
         elif isinstance(index, str):
-            if index.startswith("@"):
+            if index.startswith('@'):
                 return self.traverse_flat(index[1:])
             else:
                 return self._data[self._id2offset[index]]
@@ -166,53 +166,53 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 return self[index.tolist()]
             else:
                 raise IndexError(
-                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
+                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
                 )
-        raise IndexError(f"Unsupported index type {typename(index)}: {index}")
+        raise IndexError(f'Unsupported index type {typename(index)}: {index}')
 
     @overload
     def __setitem__(
         self,
-        index: "DocumentArrayMultipleAttributeType",
-        value: List[List["Any"]],
+        index: 'DocumentArrayMultipleAttributeType',
+        value: List[List['Any']],
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: "DocumentArraySingleAttributeType",
-        value: List["Any"],
+        index: 'DocumentArraySingleAttributeType',
+        value: List['Any'],
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: "DocumentArraySingletonIndexType",
-        value: "Document",
+        index: 'DocumentArraySingletonIndexType',
+        value: 'Document',
     ):
         ...
 
     @overload
     def __setitem__(
         self,
-        index: "DocumentArrayMultipleIndexType",
-        value: Sequence["Document"],
+        index: 'DocumentArrayMultipleIndexType',
+        value: Sequence['Document'],
     ):
         ...
 
     def __setitem__(
         self,
-        index: "DocumentArrayIndexType",
-        value: Union["Document", Sequence["Document"]],
+        index: 'DocumentArrayIndexType',
+        value: Union['Document', Sequence['Document']],
     ):
         if isinstance(index, (int, np.generic)):
             index = int(index)
             self._data[index] = value
             self._id2offset[value.id] = index
         elif isinstance(index, str):
-            if index.startswith("@"):
+            if index.startswith('@'):
                 for _d, _v in zip(self.traverse_flat(index[1:]), value):
                     _d._data = _v._data
                 self._rebuild_id2offset()
@@ -251,9 +251,9 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                     value = (value,)
 
                 for _a, _v in zip(_attrs, value):
-                    if _a == "blob":
+                    if _a == 'blob':
                         _docs.blobs = _v
-                    elif _a == "embedding":
+                    elif _a == 'embedding':
                         _docs.embeddings = _v
                     else:
                         for _d, _vv in zip(_docs, _v):
@@ -261,8 +261,8 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             elif isinstance(index[0], bool):
                 if len(index) != len(self._data):
                     raise IndexError(
-                        f"Boolean mask index is required to have the same length as {len(self._data)}, "
-                        f"but receiving {len(index)}"
+                        f'Boolean mask index is required to have the same length as {len(self._data)}, '
+                        f'but receiving {len(index)}'
                     )
                 _selected = itertools.compress(self._data, index)
                 for _idx, _val in zip(_selected, value):
@@ -270,8 +270,8 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             elif isinstance(index[0], (int, str)):
                 if not isinstance(value, Sequence) or len(index) != len(value):
                     raise ValueError(
-                        f"Number of elements for assigning must be "
-                        f"the same as the index length: {len(index)}"
+                        f'Number of elements for assigning must be '
+                        f'the same as the index length: {len(index)}'
                     )
                 if isinstance(value, Document):
                     for si in index:
@@ -285,20 +285,20 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 self[index.tolist()] = value
             else:
                 raise IndexError(
-                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
+                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
                 )
         else:
-            raise IndexError(f"Unsupported index type {typename(index)}: {index}")
+            raise IndexError(f'Unsupported index type {typename(index)}: {index}')
 
-    def __delitem__(self, index: "DocumentArrayIndexType"):
+    def __delitem__(self, index: 'DocumentArrayIndexType'):
         if isinstance(index, (int, np.generic)):
             index = int(index)
             self._id2offset.pop(self._data[index].id)
             del self._data[index]
         elif isinstance(index, str):
-            if index.startswith("@"):
+            if index.startswith('@'):
                 raise NotImplementedError(
-                    "Delete elements along traversal paths is not implemented"
+                    'Delete elements along traversal paths is not implemented'
                 )
             else:
                 del self._data[self._id2offset[index]]
@@ -338,10 +338,10 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 del self[index.tolist()]
             else:
                 raise IndexError(
-                    f"When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}"
+                    f'When using np.ndarray as index, its `ndim` must =1. However, receiving ndim={index.ndim}'
                 )
         else:
-            raise IndexError(f"Unsupported index type {typename(index)}: {index}")
+            raise IndexError(f'Unsupported index type {typename(index)}: {index}')
 
     def clear(self):
         """Clear the data of :class:`DocumentArray`"""
@@ -356,9 +356,9 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
         return len(self) > 0
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} (length={len(self)}) at {id(self)}>"
+        return f'<{self.__class__.__name__} (length={len(self)}) at {id(self)}>'
 
-    def __add__(self, other: "Document"):
+    def __add__(self, other: 'Document'):
         v = type(self)()
         for doc in self:
             v.append(doc)
@@ -366,6 +366,6 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
             v.append(doc)
         return v
 
-    def extend(self, values: Iterable["Document"]) -> None:
+    def extend(self, values: Iterable['Document']) -> None:
         self._data.extend(values)
         self._rebuild_id2offset()

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -239,7 +239,7 @@ def test_ids():
     da = DocumentArray([Document(id='1'), Document(id='2'), Document(id='3')])
 
     # da[id, attribute]
-    assert da['1', 'id'] == 1
+    assert len(da['1', 'id']) == 1
     # da[Sequence[id]]
     assert len(da['1', '2']) == 2
     assert len(da['1', '2', '3']) == 3

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -24,21 +24,21 @@ def test_getter_int_str(docarray100):
         docarray100[100]
 
     with pytest.raises(KeyError):
-        docarray100['adsad']
+        docarray100["adsad"]
 
 
 def test_setter_int_str(docarray100):
     # setter
-    docarray100[99] = Document(text='hello')
-    docarray100[0] = Document(text='world')
+    docarray100[99] = Document(text="hello")
+    docarray100[0] = Document(text="world")
 
-    assert docarray100[99].text == 'hello'
-    assert docarray100[-1].text == 'hello'
-    assert docarray100[0].text == 'world'
+    assert docarray100[99].text == "hello"
+    assert docarray100[-1].text == "hello"
+    assert docarray100[0].text == "world"
 
-    docarray100[docarray100[2].id] = Document(text='doc2')
+    docarray100[docarray100[2].id] = Document(text="doc2")
     # string index
-    assert docarray100[docarray100[2].id].text == 'doc2'
+    assert docarray100[docarray100[2].id].text == "doc2"
 
 
 def test_del_int_str(docarray100):
@@ -61,12 +61,12 @@ def test_slice(docarray100):
     assert len(docarray100[1:100:5]) == 20  # 1 to 100, sep with 5
 
     # setter
-    with pytest.raises(TypeError, match='can only assign an iterable'):
-        docarray100[1:5] = Document(text='repl')
+    with pytest.raises(TypeError, match="can only assign an iterable"):
+        docarray100[1:5] = Document(text="repl")
 
-    docarray100[1:5] = [Document(text=f'repl{j}') for j in range(4)]
+    docarray100[1:5] = [Document(text=f"repl{j}") for j in range(4)]
     for d in docarray100[1:5]:
-        assert d.text.startswith('repl')
+        assert d.text.startswith("repl")
     assert len(docarray100) == 100
 
     # del
@@ -86,12 +86,12 @@ def test_sequence_bool_index(docarray100):
 
     # setter
     mask = [True, False] * 50
-    docarray100[mask] = [Document(text=f'repl{j}') for j in range(50)]
+    docarray100[mask] = [Document(text=f"repl{j}") for j in range(50)]
 
     for idx, d in enumerate(docarray100):
         if idx % 2 == 0:
             # got replaced
-            assert d.text.startswith('repl')
+            assert d.text.startswith("repl")
         else:
             assert isinstance(d.text, int)
 
@@ -103,16 +103,16 @@ def test_sequence_bool_index(docarray100):
     assert len(docarray100) == 25
 
 
-@pytest.mark.parametrize('nparray', [lambda x: x, np.array, tuple])
+@pytest.mark.parametrize("nparray", [lambda x: x, np.array, tuple])
 def test_sequence_int(docarray100, nparray):
     # getter
     idx = nparray([1, 3, 5, 7, -1, -2])
     assert len(docarray100[idx]) == len(idx)
 
     # setter
-    docarray100[idx] = [Document(text='repl') for _ in range(len(idx))]
+    docarray100[idx] = [Document(text="repl") for _ in range(len(idx))]
     for _id in idx:
-        assert docarray100[_id].text == 'repl'
+        assert docarray100[_id].text == "repl"
 
     # del
     idx = [-3, -4, -5, 9, 10, 11]
@@ -128,10 +128,10 @@ def test_sequence_str(docarray100):
     assert len(docarray100[tuple(idx)]) == len(idx)
 
     # setter
-    docarray100[idx] = [Document(text='repl') for _ in range(len(idx))]
+    docarray100[idx] = [Document(text="repl") for _ in range(len(idx))]
     idx = [d.id for d in docarray100[1, 3, 5, 7, -1, -2]]
     for _id in idx:
-        assert docarray100[_id].text == 'repl'
+        assert docarray100[_id].text == "repl"
 
     # del
     idx = [d.id for d in docarray100[-3, -4, -5, 9, 10, 11]]
@@ -151,38 +151,38 @@ def test_path_syntax_indexing():
         d.matches = DocumentArray.empty(7)
         for c in d.chunks:
             c.chunks = DocumentArray.empty(3)
-    assert len(da['@c']) == 3 * 5
-    assert len(da['@c:1']) == 3
-    assert len(da['@c-1:']) == 3
-    assert len(da['@c1']) == 3
-    assert len(da['@c-2:']) == 3 * 2
-    assert len(da['@c1:3']) == 3 * 2
-    assert len(da['@c1:3c']) == (3 * 2) * 3
-    assert len(da['@c1:3,c1:3c']) == (3 * 2) + (3 * 2) * 3
-    assert len(da['@c 1:3 , c 1:3 c']) == (3 * 2) + (3 * 2) * 3
-    assert len(da['@cc']) == 3 * 5 * 3
-    assert len(da['@cc,m']) == 3 * 5 * 3 + 3 * 7
-    assert len(da['@r:1cc,m']) == 1 * 5 * 3 + 3 * 7
+    assert len(da["@c"]) == 3 * 5
+    assert len(da["@c:1"]) == 3
+    assert len(da["@c-1:"]) == 3
+    assert len(da["@c1"]) == 3
+    assert len(da["@c-2:"]) == 3 * 2
+    assert len(da["@c1:3"]) == 3 * 2
+    assert len(da["@c1:3c"]) == (3 * 2) * 3
+    assert len(da["@c1:3,c1:3c"]) == (3 * 2) + (3 * 2) * 3
+    assert len(da["@c 1:3 , c 1:3 c"]) == (3 * 2) + (3 * 2) * 3
+    assert len(da["@cc"]) == 3 * 5 * 3
+    assert len(da["@cc,m"]) == 3 * 5 * 3 + 3 * 7
+    assert len(da["@r:1cc,m"]) == 1 * 5 * 3 + 3 * 7
 
 
 def test_attribute_indexing():
     da = DocumentArray.empty(10)
-    for v in da[:, 'id']:
+    for v in da[:, "id"]:
         assert v
-    da[:, 'mime_type'] = [f'type {j}' for j in range(10)]
-    for v in da[:, 'mime_type']:
+    da[:, "mime_type"] = [f"type {j}" for j in range(10)]
+    for v in da[:, "mime_type"]:
         assert v
-    del da[:, 'mime_type']
-    for v in da[:, 'mime_type']:
+    del da[:, "mime_type"]
+    for v in da[:, "mime_type"]:
         assert not v
 
-    da[:, ['text', 'mime_type']] = [
-        [f'hello {j}' for j in range(10)],
-        [f'type {j}' for j in range(10)],
+    da[:, ["text", "mime_type"]] = [
+        [f"hello {j}" for j in range(10)],
+        [f"type {j}" for j in range(10)],
     ]
     da.summary()
 
-    for v in da[:, ['mime_type', 'text']]:
+    for v in da[:, ["mime_type", "text"]]:
         for vv in v:
             assert vv
 
@@ -196,18 +196,18 @@ def test_blob_attribute_selector():
 
     da = DocumentArray.empty(3)
 
-    da[:, 'embedding'] = sp_embed
+    da[:, "embedding"] = sp_embed
 
-    assert da[:, 'embedding'].shape == (3, 10)
+    assert da[:, "embedding"].shape == (3, 10)
 
     for d in da:
         assert d.embedding.shape == (1, 10)
 
-    v1, v2 = da[:, ['embedding', 'id']]
+    v1, v2 = da[:, ["embedding", "id"]]
     assert isinstance(v1, scipy.sparse.coo_matrix)
     assert isinstance(v2, list)
 
-    v1, v2 = da[:, ['id', 'embedding']]
+    v1, v2 = da[:, ["id", "embedding"]]
     assert isinstance(v2, scipy.sparse.coo_matrix)
     assert isinstance(v1, list)
 
@@ -217,8 +217,8 @@ def test_advance_selector_mixed():
     da.embeddings = np.random.random([10, 3])
     da.match(da, exclude_self=True)
 
-    assert len(da[:, ('id', 'embedding', 'matches')]) == 3
-    assert len(da[:, ('id', 'embedding', 'matches')][0]) == 10
+    assert len(da[:, ("id", "embedding", "matches")]) == 3
+    assert len(da[:, ("id", "embedding", "matches")][0]) == 10
 
 
 def test_single_boolean_and_padding():
@@ -236,10 +236,7 @@ def test_single_boolean_and_padding():
 def test_sequence_ids():
     from docarray import DocumentArray
 
-    da = DocumentArray([Document(id='1'),
-                        Document(id='2'),
-                        Document(id='3')])
+    da = DocumentArray([Document(id="1"), Document(id="2"), Document(id="3")])
 
-    assert len(da['1', '2']) == 2
-    assert len(da['1', '2', '3']) == 3
-
+    assert len(da["1", "2"]) == 2
+    assert len(da["1", "2", "3"]) == 3

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -24,7 +24,7 @@ def test_getter_int_str(docarray100):
         docarray100[100]
 
     with pytest.raises(KeyError):
-        docarray100[adsad]
+        docarray100['adsad']
 
 
 def test_setter_int_str(docarray100):
@@ -66,7 +66,7 @@ def test_slice(docarray100):
 
     docarray100[1:5] = [Document(text=f'repl{j}') for j in range(4)]
     for d in docarray100[1:5]:
-        assert d.text.startswith(repl)
+        assert d.text.startswith('repl')
     assert len(docarray100) == 100
 
     # del
@@ -155,7 +155,7 @@ def test_path_syntax_indexing():
     assert len(da['@c:1']) == 3
     assert len(da['@c-1:']) == 3
     assert len(da['@c1']) == 3
-    assert len(da[@c-2:]) == 3 * 2
+    assert len(da['@c-2:']) == 3 * 2
     assert len(da['@c1:3']) == 3 * 2
     assert len(da['@c1:3c']) == (3 * 2) * 3
     assert len(da['@c1:3,c1:3c']) == (3 * 2) + (3 * 2) * 3
@@ -169,7 +169,7 @@ def test_attribute_indexing():
     da = DocumentArray.empty(10)
     for v in da[:, 'id']:
         assert v
-    da[:, 'mime_type'] = [f'type {j} for j in range(10)]
+    da[:, 'mime_type'] = [f'type {j}' for j in range(10)]
     for v in da[:, 'mime_type']:
         assert v
     del da[:, 'mime_type']
@@ -182,7 +182,7 @@ def test_attribute_indexing():
     ]
     da.summary()
 
-    for v in da[:, ['mime_type', text]]:
+    for v in da[:, ['mime_type', 'text']]:
         for vv in v:
             assert vv
 
@@ -233,10 +233,13 @@ def test_single_boolean_and_padding():
     assert len(da[False, False]) == 0
 
 
-def test_sequence_ids():
+def test_ids():
     from docarray import DocumentArray
 
-    da = DocumentArray([Document(id='1'), Document(id='2'), Document(id='3')])
+    da = DocumentArray([Document(id='1'),
+                        Document(id='2'),
+                        Document(id='3')])
 
     assert len(da['1', '2']) == 2
     assert len(da['1', '2', '3']) == 3
+

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -240,7 +240,6 @@ def test_sequence_ids():
                         Document(id='2'),
                         Document(id='3')])
 
-    assert len(da['1']) == 1
     assert len(da['1', '2']) == 2
     assert len(da['1', '2', '3']) == 3
 

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -236,10 +236,7 @@ def test_single_boolean_and_padding():
 def test_ids():
     from docarray import DocumentArray
 
-    da = DocumentArray([Document(id='1'),
-                        Document(id='2'),
-                        Document(id='3')])
+    da = DocumentArray([Document(id='1'), Document(id='2'), Document(id='3')])
 
     assert len(da['1', '2']) == 2
     assert len(da['1', '2', '3']) == 3
-

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -238,5 +238,11 @@ def test_ids():
 
     da = DocumentArray([Document(id='1'), Document(id='2'), Document(id='3')])
 
+    # da[id, attribute]
+    assert da['1', 'id'] == 1
+    # da[Sequence[id]]
     assert len(da['1', '2']) == 2
     assert len(da['1', '2', '3']) == 3
+    # da[Sequence[id], attribute]
+    assert len(da[['1', '2'], 'id']) == 2
+    assert len(da[['1', '2', '3'], 'id']) == 3

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -24,21 +24,21 @@ def test_getter_int_str(docarray100):
         docarray100[100]
 
     with pytest.raises(KeyError):
-        docarray100["adsad"]
+        docarray100[adsad]
 
 
 def test_setter_int_str(docarray100):
     # setter
-    docarray100[99] = Document(text="hello")
-    docarray100[0] = Document(text="world")
+    docarray100[99] = Document(text='hello')
+    docarray100[0] = Document(text='world')
 
-    assert docarray100[99].text == "hello"
-    assert docarray100[-1].text == "hello"
-    assert docarray100[0].text == "world"
+    assert docarray100[99].text == 'hello'
+    assert docarray100[-1].text == 'hello'
+    assert docarray100[0].text == 'world'
 
-    docarray100[docarray100[2].id] = Document(text="doc2")
+    docarray100[docarray100[2].id] = Document(text='doc2')
     # string index
-    assert docarray100[docarray100[2].id].text == "doc2"
+    assert docarray100[docarray100[2].id].text == 'doc2'
 
 
 def test_del_int_str(docarray100):
@@ -61,12 +61,12 @@ def test_slice(docarray100):
     assert len(docarray100[1:100:5]) == 20  # 1 to 100, sep with 5
 
     # setter
-    with pytest.raises(TypeError, match="can only assign an iterable"):
-        docarray100[1:5] = Document(text="repl")
+    with pytest.raises(TypeError, match='can only assign an iterable'):
+        docarray100[1:5] = Document(text='repl')
 
-    docarray100[1:5] = [Document(text=f"repl{j}") for j in range(4)]
+    docarray100[1:5] = [Document(text=f'repl{j}') for j in range(4)]
     for d in docarray100[1:5]:
-        assert d.text.startswith("repl")
+        assert d.text.startswith(repl)
     assert len(docarray100) == 100
 
     # del
@@ -86,12 +86,12 @@ def test_sequence_bool_index(docarray100):
 
     # setter
     mask = [True, False] * 50
-    docarray100[mask] = [Document(text=f"repl{j}") for j in range(50)]
+    docarray100[mask] = [Document(text=f'repl{j}') for j in range(50)]
 
     for idx, d in enumerate(docarray100):
         if idx % 2 == 0:
             # got replaced
-            assert d.text.startswith("repl")
+            assert d.text.startswith('repl')
         else:
             assert isinstance(d.text, int)
 
@@ -103,16 +103,16 @@ def test_sequence_bool_index(docarray100):
     assert len(docarray100) == 25
 
 
-@pytest.mark.parametrize("nparray", [lambda x: x, np.array, tuple])
+@pytest.mark.parametrize('nparray', [lambda x: x, np.array, tuple])
 def test_sequence_int(docarray100, nparray):
     # getter
     idx = nparray([1, 3, 5, 7, -1, -2])
     assert len(docarray100[idx]) == len(idx)
 
     # setter
-    docarray100[idx] = [Document(text="repl") for _ in range(len(idx))]
+    docarray100[idx] = [Document(text='repl') for _ in range(len(idx))]
     for _id in idx:
-        assert docarray100[_id].text == "repl"
+        assert docarray100[_id].text == 'repl'
 
     # del
     idx = [-3, -4, -5, 9, 10, 11]
@@ -128,10 +128,10 @@ def test_sequence_str(docarray100):
     assert len(docarray100[tuple(idx)]) == len(idx)
 
     # setter
-    docarray100[idx] = [Document(text="repl") for _ in range(len(idx))]
+    docarray100[idx] = [Document(text='repl') for _ in range(len(idx))]
     idx = [d.id for d in docarray100[1, 3, 5, 7, -1, -2]]
     for _id in idx:
-        assert docarray100[_id].text == "repl"
+        assert docarray100[_id].text == 'repl'
 
     # del
     idx = [d.id for d in docarray100[-3, -4, -5, 9, 10, 11]]
@@ -151,38 +151,38 @@ def test_path_syntax_indexing():
         d.matches = DocumentArray.empty(7)
         for c in d.chunks:
             c.chunks = DocumentArray.empty(3)
-    assert len(da["@c"]) == 3 * 5
-    assert len(da["@c:1"]) == 3
-    assert len(da["@c-1:"]) == 3
-    assert len(da["@c1"]) == 3
-    assert len(da["@c-2:"]) == 3 * 2
-    assert len(da["@c1:3"]) == 3 * 2
-    assert len(da["@c1:3c"]) == (3 * 2) * 3
-    assert len(da["@c1:3,c1:3c"]) == (3 * 2) + (3 * 2) * 3
-    assert len(da["@c 1:3 , c 1:3 c"]) == (3 * 2) + (3 * 2) * 3
-    assert len(da["@cc"]) == 3 * 5 * 3
-    assert len(da["@cc,m"]) == 3 * 5 * 3 + 3 * 7
-    assert len(da["@r:1cc,m"]) == 1 * 5 * 3 + 3 * 7
+    assert len(da['@c']) == 3 * 5
+    assert len(da['@c:1']) == 3
+    assert len(da['@c-1:']) == 3
+    assert len(da['@c1']) == 3
+    assert len(da[@c-2:]) == 3 * 2
+    assert len(da['@c1:3']) == 3 * 2
+    assert len(da['@c1:3c']) == (3 * 2) * 3
+    assert len(da['@c1:3,c1:3c']) == (3 * 2) + (3 * 2) * 3
+    assert len(da['@c 1:3 , c 1:3 c']) == (3 * 2) + (3 * 2) * 3
+    assert len(da['@cc']) == 3 * 5 * 3
+    assert len(da['@cc,m']) == 3 * 5 * 3 + 3 * 7
+    assert len(da['@r:1cc,m']) == 1 * 5 * 3 + 3 * 7
 
 
 def test_attribute_indexing():
     da = DocumentArray.empty(10)
-    for v in da[:, "id"]:
+    for v in da[:, 'id']:
         assert v
-    da[:, "mime_type"] = [f"type {j}" for j in range(10)]
-    for v in da[:, "mime_type"]:
+    da[:, 'mime_type'] = [f'type {j} for j in range(10)]
+    for v in da[:, 'mime_type']:
         assert v
-    del da[:, "mime_type"]
-    for v in da[:, "mime_type"]:
+    del da[:, 'mime_type']
+    for v in da[:, 'mime_type']:
         assert not v
 
-    da[:, ["text", "mime_type"]] = [
-        [f"hello {j}" for j in range(10)],
-        [f"type {j}" for j in range(10)],
+    da[:, ['text', 'mime_type']] = [
+        [f'hello {j}' for j in range(10)],
+        [f'type {j}' for j in range(10)],
     ]
     da.summary()
 
-    for v in da[:, ["mime_type", "text"]]:
+    for v in da[:, ['mime_type', text]]:
         for vv in v:
             assert vv
 
@@ -196,18 +196,18 @@ def test_blob_attribute_selector():
 
     da = DocumentArray.empty(3)
 
-    da[:, "embedding"] = sp_embed
+    da[:, 'embedding'] = sp_embed
 
-    assert da[:, "embedding"].shape == (3, 10)
+    assert da[:, 'embedding'].shape == (3, 10)
 
     for d in da:
         assert d.embedding.shape == (1, 10)
 
-    v1, v2 = da[:, ["embedding", "id"]]
+    v1, v2 = da[:, ['embedding', 'id']]
     assert isinstance(v1, scipy.sparse.coo_matrix)
     assert isinstance(v2, list)
 
-    v1, v2 = da[:, ["id", "embedding"]]
+    v1, v2 = da[:, ['id', 'embedding']]
     assert isinstance(v2, scipy.sparse.coo_matrix)
     assert isinstance(v1, list)
 
@@ -217,8 +217,8 @@ def test_advance_selector_mixed():
     da.embeddings = np.random.random([10, 3])
     da.match(da, exclude_self=True)
 
-    assert len(da[:, ("id", "embedding", "matches")]) == 3
-    assert len(da[:, ("id", "embedding", "matches")][0]) == 10
+    assert len(da[:, ('id', 'embedding', 'matches')]) == 3
+    assert len(da[:, ('id', 'embedding', 'matches')][0]) == 10
 
 
 def test_single_boolean_and_padding():
@@ -236,7 +236,7 @@ def test_single_boolean_and_padding():
 def test_sequence_ids():
     from docarray import DocumentArray
 
-    da = DocumentArray([Document(id="1"), Document(id="2"), Document(id="3")])
+    da = DocumentArray([Document(id='1'), Document(id='2'), Document(id='3')])
 
-    assert len(da["1", "2"]) == 2
-    assert len(da["1", "2", "3"]) == 3
+    assert len(da['1', '2']) == 2
+    assert len(da['1', '2', '3']) == 3

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -231,3 +231,16 @@ def test_single_boolean_and_padding():
 
     assert len(da[True, False]) == 1
     assert len(da[False, False]) == 0
+
+
+def test_sequence_ids():
+    from docarray import DocumentArray
+
+    da = DocumentArray([Document(id='1'),
+                        Document(id='2'),
+                        Document(id='3')])
+
+    assert len(da['1']) == 1
+    assert len(da['1', '2']) == 2
+    assert len(da['1', '2', '3']) == 3
+


### PR DESCRIPTION
The `DocumentArray` method `__getitem__`  is incorrect in the case two ids are passed:

Minimal working example to showcase bug:

```python
In [2]: from docarray import Document, DocumentArray
   ...: 
   ...: da = DocumentArray([Document(id='1'),
   ...:                     Document(id='2'),
   ...:                     Document(id='3')])
```

Currently selecting with two doc ids produces 

```python
In [4]: da['1','2']

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/var/folders/05/h71x7gh54sx_5y43ppkq9_dw0000gq/T/ipykernel_8535/2066379862.py in <module>
----> 1 da['1','2']

~/Documents/jina_stuff/docarray/docarray/array/document.py in __getitem__(self, index)
    151                 if isinstance(_attrs, str):
    152                     _attrs = (index[1],)
--> 153                 return _docs._get_attributes(*_attrs)
    154             elif isinstance(index[0], bool):
    155                 return DocumentArray(itertools.compress(self._data, index))

~/Documents/jina_stuff/docarray/docarray/document/mixins/attribute.py in _get_attributes(self, *fields)
     20                 value = dunder_get(self, k)
     21             else:
---> 22                 value = getattr(self, k)
     23 
     24             ret.append(value)

AttributeError: 'Document' object has no attribute '2'
```

This PR solves this and produces
```python
In [3]: da['1']
Out[3]: <Document ('id',) at 1>

In [4]: da['1','2']
Out[4]: <DocumentArray (length=2) at 140552956821312>

In [5]: da['1','2','3']
Out[5]: <DocumentArray (length=3) at 140552956819056>
```


