### PR TITLE
fix: id_to_index initialization

### DIFF
--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -47,7 +47,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                 self._rebuild_id2offset()
             elif isinstance(docs, DocumentArray):
                 self._data = docs._data
-                self._id_to_index = docs._id_to_index
+                self._id_to_index = docs._id2offset
             else:
                 self._data = list(docs)
                 self._rebuild_id2offset()


### PR DESCRIPTION
An empty DA instance cannot be assigned to a new DA instance, as shown in the following:
```
from docarray import Document, DocumentArray

matches = DocumentArray()

query = Document()
query.matches = matches
```

yields
```
AttributeError: 'DocumentArray' object has no attribute '_id_to_index'
```