### PR TITLE
fix: single doc set in docarray

### DIFF
--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -211,6 +211,7 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
         index: 'DocumentArrayIndexType',
         value: Union['Document', Sequence['Document']],
     ):
+
         if isinstance(index, (int, np.generic)) and not isinstance(index, bool):
             index = int(index)
             self._data[index] = value
@@ -274,8 +275,11 @@ class DocumentArray(AllMixins, MutableSequence[Document]):
                         elif _a == 'embedding':
                             _docs.embeddings = _v
                         else:
-                            for _d, _vv in zip(_docs, _v):
-                                setattr(_d, _a, _vv)
+                            if len(_docs) == 1:
+                                setattr(_docs[0], _a, _v)
+                            else:
+                                for _d, _vv in zip(_docs, _v):
+                                    setattr(_d, _a, _vv)
             elif isinstance(index[0], bool):
                 if len(index) != len(self._data):
                     raise IndexError(

--- a/docarray/types.py
+++ b/docarray/types.py
@@ -48,8 +48,13 @@ if TYPE_CHECKING:
     DocumentArrayMultipleIndexType = Union[
         slice, Sequence[int], Sequence[str], Sequence[bool], Ellipsis
     ]
-    DocumentArraySingleAttributeType = Tuple[Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType], str]
-    DocumentArrayMultipleAttributeType = Tuple[Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType], Sequence[str]]
+    DocumentArraySingleAttributeType = Tuple[
+        Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType], str
+    ]
+    DocumentArrayMultipleAttributeType = Tuple[
+        Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType],
+        Sequence[str],
+    ]
     DocumentArrayIndexType = Union[
         DocumentArraySingletonIndexType,
         DocumentArrayMultipleIndexType,

--- a/docarray/types.py
+++ b/docarray/types.py
@@ -48,8 +48,8 @@ if TYPE_CHECKING:
     DocumentArrayMultipleIndexType = Union[
         slice, Sequence[int], Sequence[str], Sequence[bool], Ellipsis
     ]
-    DocumentArraySingleAttributeType = Tuple[slice, str]
-    DocumentArrayMultipleAttributeType = Tuple[slice, Sequence[str]]
+    DocumentArraySingleAttributeType = Tuple[Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType], str]
+    DocumentArrayMultipleAttributeType = Tuple[Union[DocumentArraySingletonIndexType, DocumentArrayMultipleIndexType], Sequence[str]]
     DocumentArrayIndexType = Union[
         DocumentArraySingletonIndexType,
         DocumentArrayMultipleIndexType,

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -93,6 +93,7 @@ def test_texts_getter_da(da):
     # so non-set str field in Pb is ''
     assert not da.texts
 
+
 @pytest.mark.parametrize('da', da_and_dam())
 def test_setter_by_sequences_in_selected_docs_da(da):
 
@@ -107,6 +108,7 @@ def test_setter_by_sequences_in_selected_docs_da(da):
 
     da[[0, 1], 'id'] = ['12', '34']
     assert ['12', '34'] == da[[0, 1], 'id']
+
 
 @pytest.mark.parametrize('da', da_and_dam())
 def test_texts_wrong_len(da):

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -93,6 +93,12 @@ def test_texts_getter_da(da):
     # so non-set str field in Pb is ''
     assert not da.texts
 
+    da[[0], 'text'] = 'jina'
+    assert 'jina' in da[[0], 'text']
+
+    da[[0, 1], 'text'] = ['jina', 'jana']
+    assert ['jina', 'jana'] == da[[0, 1], 'text']
+
 
 @pytest.mark.parametrize('da', da_and_dam())
 def test_texts_wrong_len(da):

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -93,12 +93,20 @@ def test_texts_getter_da(da):
     # so non-set str field in Pb is ''
     assert not da.texts
 
+@pytest.mark.parametrize('da', da_and_dam())
+def test_setter_by_sequences_in_selected_docs_da(da):
+
     da[[0], 'text'] = 'jina'
-    assert 'jina' in da[[0], 'text']
+    assert ['jina'] == da[[0], 'text']
 
     da[[0, 1], 'text'] = ['jina', 'jana']
     assert ['jina', 'jana'] == da[[0, 1], 'text']
 
+    da[[0], 'id'] = '12'
+    assert ['12'] == da[[0], 'id']
+
+    da[[0, 1], 'id'] = ['12', '34']
+    assert ['12', '34'] == da[[0, 1], 'id']
 
 @pytest.mark.parametrize('da', da_and_dam())
 def test_texts_wrong_len(da):


### PR DESCRIPTION
Currently setting for example `.text` the attribute for a concrete `Document` in a  `DocumentArray`  results to setting the first character in the string. 

```python

# this works as expected in master
from docarray import Document, DocumentArray
da = DocumentArray([Document(),Document(), Document()])
da[[0,1],'text'] = ['jina','jana']
print(da[:,'text'])

# this does NOT work as expected in master
from docarray import Document, DocumentArray
da = DocumentArray([Document(),Document(), Document()])
da[[0],'text'] = 'jina'
print(da[:,'text'])

# this does NOT work as expected in master
import numpy as np
from docarray import Document, DocumentArray
da = DocumentArray([Document(),Document(), Document()])
da[[0],'id'] = '1234'
print(da[:,'id'])
```
In master 
```
['jina', 'jana', '']
['j', '', '']
['1', 'b6ac7ce073ba11ecbdc7787b8ab3f5de', 'b6ac7d3073ba11ecbdc7787b8ab3f5de']
```

This happens because the setter has the sets the values in  `for _d, _vv in zip(_docs, _v)` and when the input data is an iterable this is not probably what the user would expect

In this PR 
```
['jina', 'jana', '']
['jina', '', '']
['1234', '92c2521e73ba11eca885787b8ab3f5de', '92c2526473ba11eca885787b8ab3f5de']
```
