### PR TITLE
fix(document): constructor overload

### DIFF
--- a/docarray/document/__init__.py
+++ b/docarray/document/__init__.py
@@ -24,6 +24,7 @@ class Document(AllMixins, BaseDCType):
     def __init__(
         self,
         _obj: Optional[Dict],
+        copy: bool = False,
         field_resolver: Optional[Dict[str, str]] = None,
         unknown_fields_handler: str = 'catch',
     ):

--- a/docarray/document/__init__.py
+++ b/docarray/document/__init__.py
@@ -1,6 +1,6 @@
-from typing import overload, Dict, Optional, List, TYPE_CHECKING, Union, Sequence
+from typing import overload, Dict, Optional, List, TYPE_CHECKING, Sequence
 
-from .data import DocumentData, default_values
+from .data import DocumentData
 from .mixins import AllMixins
 from ..base import BaseDCType
 
@@ -18,15 +18,6 @@ class Document(AllMixins, BaseDCType):
 
     @overload
     def __init__(self, _obj: Optional['Document'] = None, copy: bool = False):
-        ...
-
-    @overload
-    def __init__(
-        self,
-        _obj: Optional[Dict],
-        field_resolver: Optional[Dict[str, str]] = None,
-        unknown_fields_handler: str = 'catch',
-    ):
         ...
 
     @overload


### PR DESCRIPTION
Removed duplicated `@overload` of `Document.__init__` and added missing `copy` parameter.