### PR TITLE
feat: storage option

### DIFF
--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -41,6 +41,10 @@ class DocumentArray(AllMixins, BaseDocumentArray):
                 from .sqlite import DocumentArraySqlite
 
                 instance = super().__new__(DocumentArraySqlite)
+            elif storage == 'weaviate':
+                from .weaviate import DocumentArrayWeaviate
+
+                instance = super().__new__(DocumentArrayWeaviate)
             else:
                 raise ValueError(f'storage=`{storage}` is not supported.')
         else:

--- a/docarray/array/mixins/delitem.py
+++ b/docarray/array/mixins/delitem.py
@@ -35,9 +35,14 @@ class DelItemMixin:
             if (
                 isinstance(index, tuple)
                 and len(index) == 2
-                and isinstance(index[0], (slice, Sequence))
+                and (
+                    isinstance(index[0], (slice, Sequence, str, int))
+                    or index[0] is Ellipsis
+                )
+                and isinstance(index[1], (str, Sequence))
             ):
-                if isinstance(index[0], str) and isinstance(index[1], str):
+                # TODO: add support for cases such as da[1, ['text', 'id']]?
+                if isinstance(index[0], (str, int)) and isinstance(index[1], str):
                     # ambiguity only comes from the second string
                     if index[1] in self:
                         del self[index[0]]

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -72,6 +72,8 @@ class SetItemMixin:
             else:
                 self._set_doc_by_id(index, value)
         elif isinstance(index, slice):
+            # TODO: handle this case da[1:3] = DocumentAray.empty(10)
+            # where length of value is longer than the slice
             self._set_docs_by_slice(index, value)
         elif index is Ellipsis:
             self._set_doc_value_pairs(self.flatten(), value)
@@ -79,8 +81,52 @@ class SetItemMixin:
             if (
                 isinstance(index, tuple)
                 and len(index) == 2
-                and isinstance(index[0], (slice, Sequence))
+                and (
+                    isinstance(index[0], (slice, Sequence, str, int))
+                    or index[0] is Ellipsis
+                )
+                and isinstance(index[1], (str, Sequence))
             ):
+                # TODO: this is added because we are still trying to figure out the proper way
+                # to set attribute and to get test_path_syntax_indexing_set to pass.
+                # we may have to refactor the following logic
+                from ..weaviate import DocumentArrayWeaviate
+                from ..memory import DocumentArrayInMemory
+
+                # NOTE: this check is not proper way to handle, but a temporary hack.
+                # writing it this way to minimize effect on other docarray classs and
+                # to make it easier to remove/refactor the following block
+                if isinstance(self, (DocumentArrayWeaviate, DocumentArrayInMemory)):
+                    if index[1] in self:
+                        # we first handle he case when second item in index is an id not attr
+                        _docs = DocumentArrayInMemory(
+                            self[index[0]]
+                        ) + DocumentArrayInMemory(self[index[1]])
+                        self._set_doc_value_pairs(_docs, value)
+                        return
+
+                    _docs = self[index[0]]
+                    if isinstance(_docs, Document):
+                        _docs = DocumentArrayInMemory(_docs)
+                        # because we've augmented docs dimension, we do the same for value
+                        value = (value,)
+
+                    attrs = index[1]
+                    if isinstance(attrs, str):
+                        attrs = (attrs,)
+                        # because we've augmented attrs dimension, we do the same for value
+                        value = (value,)
+
+                    for attr in attrs:
+                        if any(not hasattr(_d, attr) for _d in _docs):
+                            raise ValueError(
+                                f'`{attr}` is neither a valid id nor attribute name'
+                            )
+
+                    for _a, _v in zip(attrs, value):
+                        self._set_docs_attrs(_docs, _a, _v)
+                    return
+
                 if isinstance(index[0], str) and isinstance(index[1], str):
                     # ambiguity only comes from the second string
                     if index[1] in self:

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -109,10 +109,12 @@ class SetItemMixin:
                     if isinstance(_docs, Document):
                         _docs = DocumentArrayInMemory(_docs)
                         # because we've augmented docs dimension, we do the same for value
+                        print('ok')
                         value = (value,)
 
                     attrs = index[1]
                     if isinstance(attrs, str):
+                        print('okk')
                         attrs = (attrs,)
                         # because we've augmented attrs dimension, we do the same for value
                         value = (value,)

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -72,8 +72,6 @@ class SetItemMixin:
             else:
                 self._set_doc_by_id(index, value)
         elif isinstance(index, slice):
-            # TODO: handle this case da[1:3] = DocumentAray.empty(10)
-            # where length of value is longer than the slice
             self._set_docs_by_slice(index, value)
         elif index is Ellipsis:
             self._set_doc_value_pairs(self.flatten(), value)

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -106,21 +106,23 @@ class SetItemMixin:
                         return
 
                     _docs = self[index[0]]
+
+                    if not _docs:
+                        return
+
                     if isinstance(_docs, Document):
                         _docs = DocumentArrayInMemory(_docs)
                         # because we've augmented docs dimension, we do the same for value
-                        print('ok')
                         value = (value,)
 
                     attrs = index[1]
                     if isinstance(attrs, str):
-                        print('okk')
                         attrs = (attrs,)
                         # because we've augmented attrs dimension, we do the same for value
                         value = (value,)
 
                     for attr in attrs:
-                        if any(not hasattr(_d, attr) for _d in _docs):
+                        if not hasattr(_docs[0], attr):
                             raise ValueError(
                                 f'`{attr}` is neither a valid id nor attribute name'
                             )

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -90,15 +90,18 @@ class SetItemMixin:
                 # TODO: this is added because we are still trying to figure out the proper way
                 # to set attribute and to get test_path_syntax_indexing_set to pass.
                 # we may have to refactor the following logic
-                from ..weaviate import DocumentArrayWeaviate
-                from ..memory import DocumentArrayInMemory
 
                 # NOTE: this check is not proper way to handle, but a temporary hack.
                 # writing it this way to minimize effect on other docarray classs and
                 # to make it easier to remove/refactor the following block
-                if isinstance(self, (DocumentArrayWeaviate, DocumentArrayInMemory)):
+                if self.__class__.__name__ in {
+                    'DocumentArrayWeaviate',
+                    'DocumentArrayInMemory',
+                }:
+                    from ..memory import DocumentArrayInMemory
+
                     if index[1] in self:
-                        # we first handle he case when second item in index is an id not attr
+                        # we first handle the case when second item in index is an id not attr
                         _docs = DocumentArrayInMemory(
                             self[index[0]]
                         ) + DocumentArrayInMemory(self[index[1]])

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -36,20 +36,29 @@ class BaseGetSetDelMixin(ABC):
 
     def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
         """This function is derived from :meth:`_get_doc_by_offset`
+        Override this function if there is a more efficient logic
 
-        Override this function if there is a more efficient logic"""
+        :param _slice: the slice used for indexing
+        :return: an iterable of document
+        """
         return (self._get_doc_by_offset(o) for o in range(len(self))[_slice])
 
     def _get_docs_by_offsets(self, offsets: Sequence[int]) -> Iterable['Document']:
         """This function is derived from :meth:`_get_doc_by_offset`
+        Override this function if there is a more efficient logic
 
-        Override this function if there is a more efficient logic"""
+        :param offsets: the offsets used for indexing
+        :return: an iterable of document
+        """
         return (self._get_doc_by_offset(o) for o in offsets)
 
     def _get_docs_by_ids(self, ids: Sequence[str]) -> Iterable['Document']:
         """This function is derived from :meth:`_get_doc_by_id`
+        Override this function if there is a more efficient logic
 
-        Override this function if there is a more efficient logic"""
+        :param ids: the ids used for indexing
+        :return: an iterable of document
+        """
         return (self._get_doc_by_id(_id) for _id in ids)
 
     # Delitem APIs
@@ -64,15 +73,17 @@ class BaseGetSetDelMixin(ABC):
 
     def _del_docs_by_slice(self, _slice: slice):
         """This function is derived and may not have the most efficient implementation.
-
-        Override this function if there is a more efficient logic"""
+        Override this function if there is a more efficient logic
+        :param _slice: the slice used for indexing
+        """
         for j in range(len(self))[_slice]:
             self._del_doc_by_offset(j)
 
     def _del_docs_by_mask(self, mask: Sequence[bool]):
         """This function is derived and may not have the most efficient implementation.
-
-        Override this function if there is a more efficient logic"""
+        Override this function if there is a more efficient logic
+        :param mask: the boolean mask used for indexing
+        """
         for idx, m in enumerate(mask):
             if not m:
                 self._del_doc_by_offset(idx)
@@ -98,6 +109,9 @@ class BaseGetSetDelMixin(ABC):
         """This function is derived and may not have the most efficient implementation.
 
         Override this function if there is a more efficient logic
+        :param _slice: the slice used for indexing
+        :param value: the value docs will be updated to
+        :raises TypeError: error raised when right-hand assignment is not an iterable
         """
         if not isinstance(value, Iterable):
             raise TypeError(
@@ -112,12 +126,14 @@ class BaseGetSetDelMixin(ABC):
         """This function is derived and may not have the most efficient implementation.
 
         Override this function if there is a more efficient logic
+        :param docs: the docs to update
+        :param values: the value docs will be updated to
         """
         for _d, _v in zip(docs, values):
             _d._data = _v._data
 
         for _d in docs:
-            if _d not in docs:
+            if _d not in self:
                 root_d = self._find_root_doc(_d)
             else:
                 # _d is already on the root-level
@@ -130,6 +146,9 @@ class BaseGetSetDelMixin(ABC):
         """This function is derived and may not have the most efficient implementation.
 
         Override this function if there is a more efficient logic
+        :param offset: the offset used for indexing
+        :param attr: the attribute of document to update
+        :param value: the value doc's attr will be updated to
         """
         d = self._get_doc_by_offset(offset)
         if hasattr(d, attr):
@@ -140,14 +159,20 @@ class BaseGetSetDelMixin(ABC):
         """This function is derived and may not have the most efficient implementation.
 
         Override this function if there is a more efficient logic
+        :param _id: the id used for indexing
+        :param attr: the attribute of document to update
+        :param value: the value doc's attr will be updated to
         """
         d = self._get_doc_by_id(_id)
         if hasattr(d, attr):
             setattr(d, attr, value)
             self._set_doc_by_id(d.id, d)
 
-    def _find_root_doc(self, d: Document):
-        """Find `d`'s root Document in an exhaustive manner"""
+    def _find_root_doc(self, d: Document) -> 'Document':
+        """Find `d`'s root Document in an exhaustive manner
+        :param: d: the input document
+        :return: the root of the input document
+        """
         from docarray import DocumentArray
 
         for _d in self:

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -121,7 +121,7 @@ class BaseGetSetDelMixin(ABC):
             self._set_doc_by_offset(_offset, val)
 
     def _set_doc_value_pairs(
-        self, docs: Iterable['Document'], values: Iterable['Document']
+        self, docs: Iterable['Document'], values: Sequence['Document']
     ):
         """This function is derived and may not have the most efficient implementation.
 
@@ -129,6 +129,13 @@ class BaseGetSetDelMixin(ABC):
         :param docs: the docs to update
         :param values: the value docs will be updated to
         """
+        docs = list(docs)
+        if len(docs) != len(values):
+            raise ValueError(
+                f'length of docs to set({len(docs)}) does not match '
+                f'length of values({len(values)})'
+            )
+
         for _d, _v in zip(docs, values):
             _d._data = _v._data
 

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -6,7 +6,7 @@ from typing import (
 )
 
 from ..base.getsetdel import BaseGetSetDelMixin
-from .... import Document
+from .... import Document, DocumentArray
 
 
 class GetSetDelMixin(BaseGetSetDelMixin):
@@ -58,9 +58,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _set_doc_attr_by_id(self, _id: str, attr: str, value: Any):
         setattr(self._data[self._id2offset[_id]], attr, value)
 
-    def _set_docs_attrs(
-        self, docs: Iterable['Document'], attr: str, values: Iterable[Any]
-    ):
+    def _set_docs_attrs(self, docs: 'DocumentArray', attr: str, values: Iterable[Any]):
         # TODO: remove this function to use _set_doc_attr_by_id once
         # we find a way to do
         if attr == 'embedding':

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -46,8 +46,15 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._rebuild_id2offset()
 
     def _set_doc_value_pairs(
-        self, docs: Iterable['Document'], values: Iterable['Document']
+        self, docs: Iterable['Document'], values: Sequence['Document']
     ):
+        docs = list(docs)
+        if len(docs) != len(values):
+            raise ValueError(
+                f'length of docs to set({len(docs)}) does not match '
+                f'length of values({len(values)})'
+            )
+
         for _d, _v in zip(docs, values):
             _d._data = _v._data
         self._rebuild_id2offset()

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -58,6 +58,19 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _set_doc_attr_by_id(self, _id: str, attr: str, value: Any):
         setattr(self._data[self._id2offset[_id]], attr, value)
 
+    def _set_docs_attrs(
+        self, docs: Iterable['Document'], attr: str, values: Iterable[Any]
+    ):
+        # TODO: remove this function to use _set_doc_attr_by_id once
+        # we find a way to do
+        if attr == 'embedding':
+            docs.embeddings = values
+        elif attr == 'tensor':
+            docs.tensors = values
+        else:
+            for _d, _v in zip(docs, values):
+                setattr(_d, attr, _v)
+
     def _get_doc_by_offset(self, offset: int) -> 'Document':
         return self._data[offset]
 

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -118,7 +118,14 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._commit()
 
     def _set_doc_value_pairs(
-        self, docs: Iterable['Document'], values: Iterable['Document']
+        self, docs: Iterable['Document'], values: Sequence['Document']
     ):
+        docs = list(docs)
+        if len(docs) != len(values):
+            raise ValueError(
+                f'length of docs to set({len(docs)}) does not match '
+                f'length of values({len(values)})'
+            )
+
         for _d, _v in zip(docs, values):
             self._set_doc_by_id(_d.id, _v)

--- a/docarray/array/storage/sqlite/seqlike.py
+++ b/docarray/array/storage/sqlite/seqlike.py
@@ -97,8 +97,3 @@ class SequenceLikeMixin(MutableSequence[Document]):
             and type(self._config) is type(other._config)
             and self._config == other._config
         )
-
-    def __add__(self, other: Union['Document', Sequence['Document']]):
-        v = type(self)(self, storage='sqlite')
-        v.extend(other)
-        return v

--- a/docarray/array/storage/weaviate/__init__.py
+++ b/docarray/array/storage/weaviate/__init__.py
@@ -1,0 +1,9 @@
+from .backend import BackendMixin
+from .getsetdel import GetSetDelMixin
+from .seqlike import SequenceLikeMixin
+
+__all__ = ['StorageMixins']
+
+
+class StorageMixins(BackendMixin, GetSetDelMixin, SequenceLikeMixin):
+    ...

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -1,0 +1,290 @@
+from dataclasses import dataclass, field
+import uuid
+import itertools
+from typing import (
+    Generator,
+    Iterator,
+    Dict,
+    Sequence,
+    Optional,
+    TYPE_CHECKING,
+    Union,
+    Tuple,
+    List,
+)
+
+import weaviate
+import uuid
+import scipy.sparse
+
+from .... import Document
+from ..base.backend import BaseBackendMixin
+
+if TYPE_CHECKING:
+    from ....types import (
+        DocumentArraySourceType,
+    )
+
+
+@dataclass
+class WeaviateConfig:
+    """This class stores the config variables to initialize
+    connection to the Weaviate server"""
+
+    client: Optional[Union[str, weaviate.Client]] = None
+    n_dim: Optional[int] = None
+    array_id: Optional[str] = None
+
+
+class BackendMixin(BaseBackendMixin):
+    """Provide necessary functions to enable this storage backend. """
+
+    def _init_storage(
+        self,
+        docs: Optional['DocumentArraySourceType'] = None,
+        config: Optional[WeaviateConfig] = None,
+    ):
+        """Initialize weaviate storage.
+
+        :param docs: the list of documents to initialize to
+        :param config: the config object used to ininitialize connection to weaviate server
+        :raises ValueError: only one of array_id or docs can be used for initialization,
+            raise an error if both are provided
+        """
+
+        from ... import DocumentArray
+
+        self._schemas = None
+
+        if not config:
+            config = WeaviateConfig()
+
+        self.n_dim = config.n_dim or 1
+
+        if config.client is None:
+            self._client = weaviate.Client('http://localhost:8080')
+        elif isinstance(config.client, str):
+            self._client = weaviate.Client(config.client)
+        else:
+            self._client = config.client
+
+        if config.array_id is not None and docs is not None:
+            raise ValueError(
+                'only one of array_id or docs can be provided for initialization'
+            )
+
+        self._schemas = self._load_or_create_weaviate_schema(config.array_id)
+        self._offset2ids, self._offset2ids_wid = self._get_offset2ids_meta()
+
+        if docs is None or config.array_id:
+            return
+
+        elif isinstance(
+            docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
+        ):
+            self.extend(Document(d, copy=True) for d in docs)
+        else:
+            if isinstance(docs, Document):
+                self.append(docs)
+
+    def _get_weaviate_class_name(self) -> str:
+        """Generate the class/schema name using the ``uuid1`` module with some
+        formatting to tailor to weaviate class name convention
+
+        :return: string representing the name of  weaviate class/schema name of
+            this :class:`DocumentArrayWeaviate` object
+        """
+        return ''.join([i for i in uuid.uuid1().hex if not i.isdigit()]).capitalize()
+
+    def _get_schema_by_name(self, cls_name: str) -> Dict:
+        """Return the schema dictionary object with the class name
+        Content of the all dictionaries by this method are the same except the name
+        of the weaviate's ``class``
+
+        :param cls_name: the name of the schema/class in weaviate
+        :return: the schema dictionary
+        """
+        # TODO: ideally we should only use one schema. this will allow us to deal with
+        # consistency better
+        return {
+            'classes': [
+                {
+                    'class': cls_name,
+                    "vectorizer": "none",
+                    # TODO: this skips checking embedding dimension but might not
+                    # work if want to leverage weaviate for vector search
+                    'vectorIndexConfig': {'skip': True},
+                    'properties': [
+                        {
+                            'dataType': ['blob'],
+                            'name': '_serialized',
+                            'indexInverted': False,
+                        },
+                    ],
+                },
+                {
+                    'class': cls_name + 'Meta',
+                    "vectorizer": "none",
+                    'vectorIndexConfig': {'skip': True},
+                    'properties': [
+                        {
+                            'dataType': ['string[]'],
+                            'name': '_offset2ids',
+                            'indexInverted': False,
+                        },
+                    ],
+                },
+            ]
+        }
+
+    def _load_or_create_weaviate_schema(self, cls_name: Optional[str] = None):
+        """Create a new weaviate schema for this :class:`DocumentArrayWeaviate` object
+        if not present in weaviate or if ``cls_name`` not provided, else if ``cls_name`` is provided
+        load the object with the given ``cls_name``
+
+        :param cls_name: if provided, load this :class:`DocumentArrayWeaviate` object with
+            the data stored in weaviate. If ``cls_name`` is ``None``, the create a schema in weaviate
+            with a newly generated class name.
+        :return: the schemas of this :class`DocumentArrayWeaviate` object and its meta
+        """
+        if not cls_name:
+            doc_schemas = self._get_schema_by_name(self._get_weaviate_class_name())
+            while self._client.schema.contains(doc_schemas):
+                doc_schemas = self._get_schema_by_name(self._get_weaviate_class_name())
+            self._client.schema.create(doc_schemas)
+            return doc_schemas
+
+        doc_schemas = self._get_schema_by_name(cls_name)
+        if self._client.schema.contains(doc_schemas):
+            return doc_schemas
+
+        self._client.schema.create(doc_schemas)
+        return doc_schemas
+
+    def _update_offset2ids_meta(self):
+        """Update the offset2ids in weaviate the the current local version"""
+        if self._offset2ids_wid is not None and self._client.data_object.exists(
+            self._offset2ids_wid
+        ):
+            self._client.data_object.update(
+                data_object={'_offset2ids': self._offset2ids},
+                class_name=self._meta_name,
+                uuid=self._offset2ids_wid,
+            )
+        else:
+            self._offset2ids_wid = str(uuid.uuid1())
+            self._client.data_object.create(
+                data_object={'_offset2ids': self._offset2ids},
+                class_name=self._meta_name,
+                uuid=self._offset2ids_wid,
+            )
+
+    def _get_offset2ids_meta(self) -> Tuple[List, str]:
+        """Return the offset2ids stored in weaviate along with the name of the schema/class
+        in weaviate that stores meta information of this object
+
+        :return: a tuple with first element as a list of offset2ids and second element
+                 being name of weaviate class/schema of the meta object
+
+        :raises ValueError: error is raised if meta class name is not defined
+        """
+        if not self._meta_name:
+            raise ValueError('meta object is not defined')
+
+        resp = (
+            self._client.query.get(self._meta_name, ['_offset2ids', '_additional {id}'])
+            .do()
+            .get('data', {})
+            .get('Get', {})
+            .get(self._meta_name, [])
+        )
+
+        if not resp:
+            return [], None
+        elif len(resp) == 1:
+            return resp[0]['_offset2ids'], resp[0]['_additional']['id']
+        else:
+            raise ValueError('received multiple meta copies which is invalid')
+
+    @property
+    def array_id(self):
+        """An alias to _class_name that returns the id/name of the class
+        in the weaviate of this :class:`DocumentArrayWeaviate`
+
+        :return: name of weaviate class/schema of this :class:`DocumentArrayWeaviate`
+        """
+        return self._class_name
+
+    @property
+    def _class_name(self):
+        """Return the name of the class in weaviate of this :class:`DocumentArrayWeaviate
+
+        :return: name of weaviate class/schema of this :class:`DocumentArrayWeaviate`
+        """
+        if not self._schemas:
+            return None
+        return self._schemas['classes'][0]['class']
+
+    @property
+    def _meta_name(self):
+        """Return the name of the class in weaviate that stores the meta information of
+        this :class:`DocumentArrayWeaviate`
+
+        :return: name of weaviate class/schema of class that stores the meta information
+        """
+        # TODO: remove this after we combine the meta info to the DocumentArray class
+        if not self._schemas:
+            return None
+        return self._schemas['classes'][1]['class']
+
+    @property
+    def _class_schema(self) -> Optional[Dict]:
+        """Return the schema dictionary of this :class:`DocumentArrayWeaviate`'s weaviate schema
+
+        :return: the dictionary representing this weaviate schema
+        """
+        if not self._schemas:
+            return None
+        return self._schemas['classes'][0]
+
+    @property
+    def _meta_schema(self):
+        """Return the schema dictionary of this weaviate schema that stores this object's meta
+
+        :return: the dictionary representing a meta object's weaviate schema
+        """
+        if not self._schemas and len(self._schemas) < 2:
+            return None
+        return self._schemas['classes'][1]
+
+    def _doc2weaviate_create_payload(self, value: 'Document'):
+        """Return the payload to store :class:`Document` into weaviate
+
+        :param value: document to create a payload for
+        :return: the payload dictionary
+        """
+        if value.embedding is None:
+            embedding = [0]
+        elif isinstance(value.embedding, scipy.sparse.spmatrix):
+            embedding = value.embedding.toarray()
+        else:
+            embedding = value.embedding
+
+        return dict(
+            data_object={'_serialized': value.to_base64()},
+            class_name=self._class_name,
+            uuid=self.wmap(value.id),
+            vector=embedding,
+        )
+
+    def wmap(self, doc_id: str):
+        """the function maps doc id to weaviate id
+
+        :param doc_id: id of the document
+        :return: weaviate object id
+        """
+        # appending class name to doc id to handle the case:
+        # daw1 = DocumentArrayWeaviate([Document(id=str(i), text='hi') for i in range(3)])
+        # daw2 = DocumentArrayWeaviate([Document(id=str(i), text='bye') for i in range(3)])
+        # daw2[0, 'text'] == 'hi' # this will be False if we don't append class name
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, doc_id + self._class_name))

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -15,6 +15,7 @@ from typing import (
 
 import uuid
 import scipy.sparse
+import weaviate
 
 from .... import Document
 from ..base.backend import BaseBackendMixin
@@ -30,7 +31,7 @@ class WeaviateConfig:
     """This class stores the config variables to initialize
     connection to the Weaviate server"""
 
-    client: Optional[Union[str, 'weaviate.Client']] = None
+    client: Optional[Union[str, weaviate.Client]] = None
     n_dim: Optional[int] = None
     name: Optional[str] = None
 

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -34,6 +34,7 @@ class WeaviateConfig:
     client: Optional[Union[str, weaviate.Client]] = None
     n_dim: Optional[int] = None
     name: Optional[str] = None
+    serialize_config: Dict = field(default_factory=lambda: {'protocol': 'pickle'})
 
 
 class BackendMixin(BaseBackendMixin):
@@ -60,6 +61,7 @@ class BackendMixin(BaseBackendMixin):
             config = WeaviateConfig()
 
         self.n_dim = config.n_dim or 1
+        self.serialize_config = config.serialize_config
 
         import weaviate
 
@@ -279,7 +281,7 @@ class BackendMixin(BaseBackendMixin):
             embedding = to_numpy_array(value.embedding)
 
         return dict(
-            data_object={'_serialized': value.to_base64()},
+            data_object={'_serialized': value.to_base64(**self.serialize_config)},
             class_name=self._class_name,
             uuid=self.wmap(value.id),
             vector=embedding,

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -13,7 +13,6 @@ from typing import (
     List,
 )
 
-import uuid
 import scipy.sparse
 import weaviate
 

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -32,9 +32,10 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         :param wid: weaviate id
         :param value: the new document to update to
         """
+        payload = self._doc2weaviate_create_payload(value)
         if self._client.data_object.exists(wid):
             self._client.data_object.delete(wid)
-        self._client.data_object.create(**self._doc2weaviate_create_payload(value))
+        self._client.data_object.create(**payload)
         self._offset2ids[self._offset2ids.index(wid)] = self.wmap(value.id)
         self._update_offset2ids_meta()
 

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -1,0 +1,205 @@
+import itertools
+from collections.abc import Iterable as _Iterable
+from typing import (
+    Sequence,
+    Iterable,
+    Any,
+)
+
+from ..base.getsetdel import BaseGetSetDelMixin
+from .... import Document
+
+
+class GetSetDelMixin(BaseGetSetDelMixin):
+    """Provide concrete implmentation for ``__getitem__``, ``__setitem__``,
+    and ``__delitem__`` for ``DoucmentArrayWeaviate``"""
+
+    def _getitem(self, wid: str) -> 'Document':
+        """Helper method for getting item with weaviate as storage
+
+        :param wid: weaviate id
+        :raises KeyError: raise error when weaviate id does not exist in storage
+        :return: Document
+        """
+        resp = self._client.data_object.get_by_id(wid, with_vector=True)
+        if not resp:
+            raise KeyError(wid)
+        return Document.from_base64(resp['properties']['_serialized'])
+
+    def _setitem(self, wid: str, value: Document):
+        """Helper method for setting an item with weaviate as storage
+
+        :param wid: weaviate id
+        :param value: the new document to update to
+        """
+        if self._client.data_object.exists(wid):
+            self._client.data_object.delete(wid)
+        self._client.data_object.create(**self._doc2weaviate_create_payload(value))
+        self._offset2ids[self._offset2ids.index(wid)] = self.wmap(value.id)
+        self._update_offset2ids_meta()
+
+    def _delitem(self, wid: str):
+        """Helper method for deleting an item with weaviate as storage
+
+        :param wid: weaviate id
+        """
+        self._client.data_object.delete(wid)
+        self._offset2ids.pop(self._offset2ids.index(wid))
+        self._update_offset2ids_meta()
+
+    def _get_doc_by_offset(self, offset: int) -> 'Document':
+        """Concrete implementation of base class' ``_get_doc_by_offset``
+
+        :param offset: the offset of the document in the list
+        :return: the retrieved document from weaviate
+        """
+        return self._getitem(self._offset2ids[offset])
+
+    def _get_doc_by_id(self, _id: str) -> 'Document':
+        """Concrete implementation of base class' ``_get_doc_by_id``
+
+        :param _id: the id of the document
+        :return: the retrieved document from weaviate
+        """
+        return self._getitem(self.wmap(_id))
+
+    def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
+        """Concrete implementation of base class' ``_get_doc_by_slice``
+
+        :param _slice: the slice of in the list to get docs from
+        :return: an iterable of retrieved documents from weaviate
+        """
+        wids = self._offset2ids[_slice]
+        return (self._getitem(wid) for wid in wids)
+
+    def _set_doc_by_offset(self, offset: int, value: 'Document'):
+        """Concrete implementation of base class' ``_set_doc_by_offset``
+
+        :param offset: the offset of doc in the list to update
+        :param value: the document to update to
+        """
+        wid = self._offset2ids[offset]
+        self._setitem(wid, value)
+        # update weaviate id
+        self._offset2ids[offset] = self.wmap(value.id)
+
+    def _set_doc_value_pairs(
+        self, docs: Iterable['Document'], values: Iterable['Document']
+    ):
+        # TODO: use base _set_doc_value_pairs
+        from .... import DocumentArray
+
+        map_doc_id_to_offset = {doc.id: offset for offset, doc in enumerate(docs)}
+        new = DocumentArray([d for d in self], copy=True)
+        for d in new.flatten():
+            if d.id not in map_doc_id_to_offset:
+                continue
+            v = values[map_doc_id_to_offset[d.id]]
+            d._data = v._data
+
+        for _d, _v in zip(self, new):
+            self._setitem(self.wmap(_d.id), _v)
+
+    def _set_doc_by_id(self, _id: str, value: 'Document'):
+        """Concrete implementation of base class' ``_set_doc_by_id``
+
+        :param _id: the id of doc to update
+        :param value: the document to update to
+        """
+        self._setitem(self.wmap(_id), value)
+
+    def _set_docs_by_slice(self, _slice: slice, values: Sequence['Document']):
+        """Concrete implementation of base class' ``_set_doc_by_slice``
+
+        :param _slice: the slice of documents in the list to update
+        :param values: the documents to update to
+        :raises TypeError: error is raised if value is not an iterable because
+            docs indexed by slice is always an array
+        """
+        wids = self._offset2ids[_slice]
+        if not isinstance(values, _Iterable):
+            raise TypeError('can only assign an iterable')
+        for _i, _v in zip(wids, values):
+            self._setitem(_i, _v)
+
+    def _set_doc_attr_by_id(self, _id: str, attr: str, value: Any):
+        """Concrete implementation of base class' ``_set_doc_attr_by_id``
+
+        :param _id: the id of the document to update
+        :param attr: the attribute to update
+        :param value: the value to set doc's ``attr`` to
+        :raises ValueError: raise an error if user tries to pop the id of the doc
+        """
+        if attr == 'id' and value is None:
+            raise ValueError('pop id from Document stored with weaviate is not allowed')
+        doc = self[_id]
+        setattr(doc, attr, value)
+        self._setitem(self.wmap(doc.id), doc)
+
+    def _set_docs_attrs(
+        self, docs: Iterable['Document'], attr: str, values: Iterable[Any]
+    ):
+        # TODO: remove this function to use _set_doc_attr_by_id once
+        # we find a way to do
+        from ...memory import DocumentArrayInMemory
+
+        if attr == 'embedding':
+            docs.embeddings = values
+        elif attr == 'tensor':
+            docs.tensors = values
+        else:
+            for d, v in zip(docs, values):
+                setattr(d, attr, v)
+
+        def _set_attr_util(_docs: DocumentArrayInMemory):
+            for d in _docs:
+                if d in docs:
+                    setattr(d, attr, getattr(docs[d.id], attr))
+                _set_attr_util(d.chunks)
+                _set_attr_util(d.matches)
+
+        res = DocumentArrayInMemory([d for d in self])
+        _set_attr_util(res)
+
+        for r in res:
+            self._setitem(self.wmap(r.id), r)
+
+    def _del_doc_by_offset(self, offset: int):
+        """Concrete implementation of base class' ``_del_doc_by_offset``
+
+        :param offset: the offset of the document to delete
+        """
+        self._delitem(self._offset2ids[offset])
+
+    def _del_doc_by_id(self, _id: str):
+        """Concrete implementation of base class' ``_del_doc_by_id``
+
+        :param _id: the id of the document to delete
+        """
+        self._delitem(self.wmap(_id))
+
+    def _del_docs_by_slice(self, _slice: slice):
+        """Concrete implementation of base class' ``_del_doc_by_slice``
+
+        :param _slice: the slice of documents to delete
+        """
+        start = _slice.start or 0
+        stop = _slice.stop or len(self)
+        step = _slice.step or 1
+        del self[list(range(start, stop, step))]
+
+    def _del_all_docs(self):
+        """ Concrete implementation of base class' ``_del_all_docs``"""
+        self._client.schema.delete_class(self._class_name)
+        self._offset2ids.clear()
+        self._upload_weaviate_schema()
+        self._update_offset2ids_meta()
+
+    def _del_docs_by_mask(self, mask: Sequence[bool]):
+        """Concrete implementation of base class' ``_del_docs_by_mask``
+
+        :param mask: the mask used for indexing which documents to delete
+        """
+        idxs = list(itertools.compress(self._offset2ids, (not _i for _i in mask)))
+        for _idx in reversed(idxs):
+            self._delitem(_idx)

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -193,6 +193,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         """ Concrete implementation of base class' ``_del_all_docs``"""
         if self._class_name:
             self._client.schema.delete_class(self._class_name)
+            self._client.schema.delete_class(self._meta_name)
             self._offset2ids.clear()
             self._load_or_create_weaviate_schema(self._class_name)
             self._update_offset2ids_meta()

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 from ..base.getsetdel import BaseGetSetDelMixin
-from .... import Document
+from .... import Document, DocumentArray
 
 
 class GetSetDelMixin(BaseGetSetDelMixin):
@@ -90,10 +90,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self, docs: Iterable['Document'], values: Iterable['Document']
     ):
         # TODO: use base _set_doc_value_pairs
-        from .... import DocumentArray
-
         map_doc_id_to_offset = {doc.id: offset for offset, doc in enumerate(docs)}
-        new = DocumentArray([d for d in self], copy=True)
+        new = DocumentArray(d for d in self)
         for d in new.flatten():
             if d.id not in map_doc_id_to_offset:
                 continue
@@ -139,9 +137,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         setattr(doc, attr, value)
         self._setitem(self.wmap(doc.id), doc)
 
-    def _set_docs_attrs(
-        self, docs: Iterable['Document'], attr: str, values: Iterable[Any]
-    ):
+    def _set_docs_attrs(self, docs: 'DocumentArray', attr: str, values: Iterable[Any]):
         # TODO: remove this function to use _set_doc_attr_by_id once
         # we find a way to do
         from ...memory import DocumentArrayInMemory

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -24,7 +24,9 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         resp = self._client.data_object.get_by_id(wid, with_vector=True)
         if not resp:
             raise KeyError(wid)
-        return Document.from_base64(resp['properties']['_serialized'])
+        return Document.from_base64(
+            resp['properties']['_serialized'], **self.serialize_config
+        )
 
     def _setitem(self, wid: str, value: Document):
         """Helper method for setting an item with weaviate as storage

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -190,10 +190,11 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _del_all_docs(self):
         """ Concrete implementation of base class' ``_del_all_docs``"""
-        self._client.schema.delete_class(self._class_name)
-        self._offset2ids.clear()
-        self._upload_weaviate_schema()
-        self._update_offset2ids_meta()
+        if self._class_name:
+            self._client.schema.delete_class(self._class_name)
+            self._offset2ids.clear()
+            self._load_or_create_weaviate_schema(self._class_name)
+            self._update_offset2ids_meta()
 
     def _del_docs_by_mask(self, mask: Sequence[bool]):
         """Concrete implementation of base class' ``_del_docs_by_mask``

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -71,10 +71,7 @@ class SequenceLikeMixin(MutableSequence[Document]):
 
     def clear(self):
         """Clear the data of :class:`DocumentArray` with weaviate storage"""
-        if self._class_name:
-            self._client.schema.delete_class(self._class_name)
-            self._offset2ids.clear()
-            self._update_offset2ids_meta()
+        self._del_all_docs()
 
     def __bool__(self):
         """To simulate ```l = []; if l: ...```

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -88,18 +88,6 @@ class SequenceLikeMixin(MutableSequence[Document]):
         """
         return f'<{self.__class__.__name__} (length={len(self)}) at {id(self)}>'
 
-    def __add__(self, other: 'Document'):
-        """Add the other document to this :class:`DocumentArrayWeaviate`
-        :param other: the other document to add
-        :return: the new :class:`DocumentArrayWeaviate` but with other added
-        """
-        v = type(self)()
-        for doc in self:
-            v.append(doc)
-        for doc in other:
-            v.append(doc)
-        return v
-
     def extend(self, values: Iterable['Document']) -> None:
         """Extends the array with the given values
 

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -1,0 +1,112 @@
+from typing import Iterator, Union, Sequence, Iterable, MutableSequence
+
+from .... import Document
+
+
+class SequenceLikeMixin(MutableSequence[Document]):
+    """Implement sequence-like methods for DocumentArray with weaviate as storage"""
+
+    def insert(self, index: int, value: 'Document'):
+        """Insert `doc` at `index`.
+
+        :param index: Position of the insertion.
+        :param value: The doc needs to be inserted.
+        """
+        self._offset2ids.insert(index, self.wmap(value.id))
+        self._client.data_object.create(**self._doc2weaviate_create_payload(value))
+        self._update_offset2ids_meta()
+
+    def __eq__(self, other):
+        """Compare this object to the other, returns True if and only if other
+        as the same type as self and other has the same meta information
+
+        :param other: the other object to check for equality
+        :return: ``True`` if other is equal to self
+        """
+        # two DAW are considered as the same if they have the same client meta data
+        return (
+            type(self) is type(other)
+            and self._client.get_meta() == other._client.get_meta()
+        )
+
+    def __len__(self):
+        """Return the length of :class:`DocumentArray` that uses weaviate as storage
+
+        :return: the length of this :class:`DocumentArrayWeaviate` object
+        """
+        cls_data = (
+            self._client.query.aggregate(self._class_name)
+            .with_meta_count()
+            .do()
+            .get('data', {})
+            .get('Aggregate', {})
+            .get(self._class_name, [])
+        )
+
+        if not cls_data:
+            return 0
+
+        return cls_data[0]['meta']['count']
+
+    def __iter__(self) -> Iterator['Document']:
+        """Iterate over all the root-level documents in the array
+
+        :yield: root-level document stored in this :class:`DocumentArrayWeaviate` object
+        """
+        for wid in range(len(self._offset2ids)):
+            yield self[wid]
+
+    def __contains__(self, x: Union[str, 'Document']):
+        """Check if ``x`` is contained in this :class:`DocumentArray` with weaviate storage
+
+        :param x: the id of the document to check or the document object itself
+        :return: True if ``x`` is contained in self
+        """
+        if isinstance(x, str):
+            return self._client.data_object.exists(self.wmap(x))
+        elif isinstance(x, Document):
+            return self._client.data_object.exists(self.wmap(x.id))
+        else:
+            return False
+
+    def clear(self):
+        """Clear the data of :class:`DocumentArray` with weaviate storage"""
+        if self._class_name:
+            self._client.schema.delete_class(self._class_name)
+            self._offset2ids.clear()
+            self._update_offset2ids_meta()
+
+    def __bool__(self):
+        """To simulate ```l = []; if l: ...```
+        :return: returns true if the length of the array is larger than 0
+        """
+        return len(self) > 0
+
+    def __repr__(self):
+        """Return the string representation of :class:`DocumentArrayWeaviate` object
+        :return: string representation of this object
+        """
+        return f'<{self.__class__.__name__} (length={len(self)}) at {id(self)}>'
+
+    def __add__(self, other: 'Document'):
+        """Add the other document to this :class:`DocumentArrayWeaviate`
+        :param other: the other document to add
+        :return: the new :class:`DocumentArrayWeaviate` but with other added
+        """
+        v = type(self)()
+        for doc in self:
+            v.append(doc)
+        for doc in other:
+            v.append(doc)
+        return v
+
+    def extend(self, values: Iterable['Document']) -> None:
+        """Extends the array with the given values
+
+        :param values: Documents to be added
+        """
+        with self._client.batch as _b:
+            for d in values:
+                _b.add_data_object(**self._doc2weaviate_create_payload(d))
+                self._offset2ids.append(self.wmap(d.id))
+        self._update_offset2ids_meta()

--- a/docarray/array/weaviate.py
+++ b/docarray/array/weaviate.py
@@ -1,0 +1,18 @@
+from .document import DocumentArray
+from .storage.weaviate import StorageMixins
+from .storage.weaviate.backend import WeaviateConfig
+
+
+class DocumentArrayWeaviate(StorageMixins, DocumentArray):
+    """This is a :class:`DocumentArray` that uses Weaviate as
+    vector search engine and storage.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        """``__new__`` method for :class:`DocumentArrayWeaviate`
+
+        :param *args: list of args to instantiate the object
+        :param **kwargs: dict of args to instantiate the object
+        :return: the instantiated :class:`DocumentArrayWeaviate` object
+        """
+        return super().__new__(cls)

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
             'onnx',
             'onnxruntime',
             'jupyterlab',
-            'weaviate-client~=3.3.0'
+            'weaviate-client~=3.3.0',
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             'av',
             'fastapi',
             'uvicorn',
+            'weaviate-client~=3.3.0',
         ],
         'test': [
             'pytest',
@@ -72,6 +73,7 @@ setup(
             'onnx',
             'onnxruntime',
             'jupyterlab',
+            'weaviate-client~=3.3.0'
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
             'onnx',
             'onnxruntime',
             'jupyterlab',
-            'weaviate-client~=3.3.0',
         ],
     },
     classifiers=[

--- a/tests/unit/array/conftest.py
+++ b/tests/unit/array/conftest.py
@@ -1,0 +1,22 @@
+import os
+import time
+
+import pytest
+
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+compose_yml = os.path.abspath(os.path.join(cur_dir, 'docker-compose.yml'))
+
+
+@pytest.fixture(scope='module')
+def start_weaviate():
+    os.system(
+        f"docker-compose -f {compose_yml} --project-directory . up  --build -d "
+        f"--remove-orphans"
+    )
+    time.sleep(5)
+    yield
+    os.system(
+        f"docker-compose -f {compose_yml} --project-directory . down "
+        f"--remove-orphans"
+    )

--- a/tests/unit/array/docker-compose.yml
+++ b/tests/unit/array/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.3"
+services:
+  weaviate:
+    image: semitechnologies/weaviate:1.9.0
+    ports:
+      - 8080:8080
+    environment:
+      CONTEXTIONARY_URL: contextionary:9999
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -97,13 +97,17 @@ def test_texts_getter_da(da):
 @pytest.mark.parametrize('da', da_and_dam())
 def test_setter_by_sequences_in_selected_docs_da(da):
 
-    da[[0], 'text'] = 'jina'
+    # TODO Clarify whether this change can be accepted
+    # I think since the first element of the index (i.e. [0])
+    # is a list, it might be more natural to expect a list
+    # as values?
+    da[[0], 'text'] = ['jina']
     assert ['jina'] == da[[0], 'text']
 
     da[[0, 1], 'text'] = ['jina', 'jana']
     assert ['jina', 'jana'] == da[[0, 1], 'text']
 
-    da[[0], 'id'] = '12'
+    da[[0], 'id'] = ['12']
     assert ['12'] == da[[0], 'id']
 
     da[[0, 1], 'id'] = ['12', '34']

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -4,20 +4,22 @@ import uuid
 import numpy as np
 import pytest
 
-from docarray import DocumentArray
+from docarray.array.memory import DocumentArrayInMemory
+from docarray.array.weaviate import DocumentArrayWeaviate
 from tests import random_docs
 
 
-def da_and_dam():
-    da = DocumentArray(random_docs(100))
-    return (da,)
+@pytest.fixture
+def docs():
+    return random_docs(100)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize('method', ['json', 'binary'])
-@pytest.mark.parametrize('da', da_and_dam())
-def test_document_save_load(method, tmp_path, da):
+@pytest.mark.parametrize('da_cls', [DocumentArrayWeaviate])
+def test_document_save_load(docs, method, tmp_path, da_cls, start_weaviate):
     tmp_file = os.path.join(tmp_path, 'test')
+    da = da_cls(docs)
     da.save(tmp_file, file_format=method)
     da_r = type(da).load(tmp_file, file_format=method)
 
@@ -30,60 +32,61 @@ def test_document_save_load(method, tmp_path, da):
 
 
 @pytest.mark.parametrize('flatten_tags', [True, False])
-@pytest.mark.parametrize('da', da_and_dam())
-def test_da_csv_write(flatten_tags, tmp_path, da):
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_da_csv_write(docs, flatten_tags, tmp_path, da_cls, start_weaviate):
     tmpfile = os.path.join(tmp_path, 'test.csv')
+    da = da_cls(docs)
     da.save_csv(tmpfile, flatten_tags)
     with open(tmpfile) as fp:
         assert len([v for v in fp]) == len(da) + 1
 
 
-@pytest.mark.parametrize('da', [DocumentArray])
-def test_from_ndarray(da):
+@pytest.mark.parametrize('da', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_from_ndarray(da, start_weaviate):
     _da = da.from_ndarray(np.random.random([10, 256]))
     assert len(_da) == 10
 
 
-@pytest.mark.parametrize('da', [DocumentArray])
-def test_from_files(da):
+@pytest.mark.parametrize('da', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_from_files(da, start_weaviate):
     assert len(da.from_files(patterns='*.*', to_dataturi=True, size=1)) == 1
 
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-@pytest.mark.parametrize('da', [DocumentArray])
-def test_from_ndjson(da):
+@pytest.mark.parametrize('da', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_from_ndjson(da, start_weaviate):
     with open(os.path.join(cur_dir, 'docs.jsonlines')) as fp:
         _da = da.from_ndjson(fp)
         assert len(_da) == 2
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
 def test_from_to_pd_dataframe(da_cls):
     # simple
     assert len(da_cls.from_dataframe(da_cls.empty(2).to_dataframe())) == 2
 
     # more complicated
     da = da_cls.empty(2)
-    da.embeddings = [[1, 2, 3], [4, 5, 6]]
-    da.tensors = [[1, 2], [2, 1]]
-    da[0].tags = {'hello': 'world'}
+    da[:, 'embedding'] = [[1, 2, 3], [4, 5, 6]]
+    da[:, 'tensor'] = [[1, 2], [2, 1]]
+    da[0, 'tags'] = {'hello': 'world'}
     da2 = da_cls.from_dataframe(da.to_dataframe())
     assert da2[0].tags == {'hello': 'world'}
     assert da2[1].tags == {}
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
 def test_from_to_bytes(da_cls):
     # simple
     assert len(da_cls.load_binary(bytes(da_cls.empty(2)))) == 2
 
     # more complicated
     da = da_cls.empty(2)
-    da.embeddings = [[1, 2, 3], [4, 5, 6]]
-    da.tensors = [[1, 2], [2, 1]]
-    da[0].tags = {'hello': 'world'}
+    da[:, 'embedding'] = [[1, 2, 3], [4, 5, 6]]
+    da[:, 'tensor'] = [[1, 2], [2, 1]]
+    da[0, 'tags'] = {'hello': 'world'}
     da2 = da_cls.load_binary(bytes(da))
     assert da2.tensors == [[1, 2], [2, 1]]
     assert da2.embeddings == [[1, 2, 3], [4, 5, 6]]
@@ -91,13 +94,13 @@ def test_from_to_bytes(da_cls):
     assert da2[1].tags == {}
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
 @pytest.mark.parametrize('show_progress', [True, False])
 def test_push_pull_io(da_cls, show_progress):
     da1 = da_cls.empty(10)
-    da1.embeddings = np.random.random([len(da1), 256])
+    da1[:, 'embedding'] = np.random.random([len(da1), 256])
     random_texts = [str(uuid.uuid1()) for _ in da1]
-    da1.texts = random_texts
+    da1[:, 'text'] = random_texts
 
     da1.push('myda', show_progress=show_progress)
 
@@ -109,11 +112,10 @@ def test_push_pull_io(da_cls, show_progress):
 
 @pytest.mark.parametrize('protocol', ['protobuf', 'pickle'])
 @pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip', None])
-def test_from_to_base64(protocol, compress):
-    da = DocumentArray.empty(10)
-    da.embeddings = [[1, 2, 3]] * len(da)
-    da_r = DocumentArray.from_base64(
-        da.to_base64(protocol, compress), protocol, compress
-    )
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_from_to_base64(protocol, compress, da_cls):
+    da = da_cls.empty(10)
+    da[:, 'embedding'] = [[1, 2, 3]] * len(da)
+    da_r = da_cls.from_base64(da.to_base64(protocol, compress), protocol, compress)
     assert da_r == da
     assert da_r[0].embedding == [1, 2, 3]

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -210,7 +210,7 @@ def test_path_syntax_indexing_set(storage, start_weaviate):
     repeat = lambda s, l: [s] * l
     da['@r,c,m,cc', 'text'] = repeat('a', 3 + 5 * 3 + 7 * 3 + 3 * 5 * 3)
 
-    if storage == 'weaviate':
+    if storage != 'memory':
         da = DocumentArray(da, storage=storage)
 
     assert da['@c', 'text'] == repeat('a', 3 * 5)
@@ -255,6 +255,9 @@ def test_path_syntax_indexing_set(storage, start_weaviate):
     da[doc_id, 'text'] = 'e'
     assert da[doc_id, 'text'] == 'e'
     assert da[doc_id].text == 'e'
+
+    da['@m'] = [Document(text='c')] * (3 * 7)
+    assert da['@m', 'text'] == repeat('c', 3 * 7)
 
     # TODO also test cases like da[1, ['text', 'id']],
     # where first index is str/int and second is attr

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from docarray import DocumentArray, Document
+from docarray.array.weaviate import DocumentArrayWeaviate
 
 
 @pytest.fixture
@@ -14,8 +15,8 @@ def indices():
     yield (i for i in [-2, 0, 2])
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_getter_int_str(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_getter_int_str(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # getter
     assert docs[99].text == 99
@@ -34,8 +35,8 @@ def test_getter_int_str(docs, storage):
         docs['adsad']
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_setter_int_str(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_setter_int_str(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # setter
     docs[99] = Document(text='hello')
@@ -50,7 +51,7 @@ def test_setter_int_str(docs, storage):
     assert docs[docs[2].id].text == 'doc2'
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
 def test_del_int_str(docs, storage, indices):
     docs = DocumentArray(docs, storage=storage)
     initial_len = len(docs)
@@ -71,8 +72,8 @@ def test_del_int_str(docs, storage, indices):
         assert new_doc_zero not in docs
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_slice(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_slice(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # getter
     assert len(docs[1:5]) == 4
@@ -96,8 +97,8 @@ def test_slice(docs, storage):
     assert twenty_doc in docs
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_sequence_bool_index(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_sequence_bool_index(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # getter
     mask = [True, False] * 50
@@ -106,8 +107,11 @@ def test_sequence_bool_index(docs, storage):
 
     # setter
     mask = [True, False] * 50
-    # docs[mask] = [Document(text=f'repl{j}') for j in range(50)]
-    docs[mask, 'text'] = [f'repl{j}' for j in range(50)]
+    # TODO: unifiy the following test logic
+    if storage == 'sqlite':
+        docs[mask, 'text'] = [f'repl{j}' for j in range(50)]
+    else:
+        docs[mask] = [Document(text=f'repl{j}') for j in range(50)]
 
     for idx, d in enumerate(docs):
         if idx % 2 == 0:
@@ -122,8 +126,8 @@ def test_sequence_bool_index(docs, storage):
 
 
 @pytest.mark.parametrize('nparray', [lambda x: x, np.array, tuple])
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_sequence_int(docs, nparray, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_sequence_int(docs, nparray, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # getter
     idx = nparray([1, 3, 5, 7, -1, -2])
@@ -140,8 +144,8 @@ def test_sequence_int(docs, nparray, storage):
     assert len(docs) == 100 - len(idx)
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_sequence_str(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_sequence_str(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     # getter
     idx = [d.id for d in docs[1, 3, 5, 7, -1, -2]]
@@ -161,15 +165,15 @@ def test_sequence_str(docs, storage):
     assert len(docs) == 100 - len(idx)
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_docarray_list_tuple(docs, storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_docarray_list_tuple(docs, storage, start_weaviate):
     docs = DocumentArray(docs, storage=storage)
     assert isinstance(docs[99, 98], DocumentArray)
     assert len(docs[99, 98]) == 2
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_path_syntax_indexing(storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_path_syntax_indexing(storage, start_weaviate):
     da = DocumentArray.empty(3)
     for d in da:
         d.chunks = DocumentArray.empty(5)
@@ -177,8 +181,9 @@ def test_path_syntax_indexing(storage):
         for c in d.chunks:
             c.chunks = DocumentArray.empty(3)
 
-    if storage == 'sqlite':
+    if storage in {'sqlite', 'weaviate'}:
         da = DocumentArray(da, storage=storage)
+
     assert len(da['@c']) == 3 * 5
     assert len(da['@c:1']) == 3
     assert len(da['@c-1:']) == 3
@@ -193,8 +198,70 @@ def test_path_syntax_indexing(storage):
     assert len(da['@r:1cc,m']) == 1 * 5 * 3 + 3 * 7
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_attribute_indexing(storage):
+@pytest.mark.parametrize('storage', ['memory', 'weaviate'])
+def test_path_syntax_indexing_set(storage, start_weaviate):
+    da = DocumentArray.empty(3)
+    for d in da:
+        d.chunks = DocumentArray.empty(5)
+        d.matches = DocumentArray.empty(7)
+        for c in d.chunks:
+            c.chunks = DocumentArray.empty(3)
+
+    repeat = lambda s, l: [s] * l
+    da['@r,c,m,cc', 'text'] = repeat('a', 3 + 5 * 3 + 7 * 3 + 3 * 5 * 3)
+
+    if storage == 'weaviate':
+        da = DocumentArray(da, storage=storage)
+
+    assert da['@c', 'text'] == repeat('a', 3 * 5)
+    assert da['@c:1', 'text'] == repeat('a', 3)
+    assert da['@c-1:', 'text'] == repeat('a', 3)
+    assert da['@c1', 'text'] == repeat('a', 3)
+    assert da['@c-2:', 'text'] == repeat('a', 3 * 2)
+    assert da['@c1:3', 'text'] == repeat('a', 3 * 2)
+    assert da['@c1:3c', 'text'] == repeat('a', (3 * 2) * 3)
+    assert da['@c1:3,c1:3c', 'text'] == repeat('a', (3 * 2) + (3 * 2) * 3)
+    assert da['@c 1:3 , c 1:3 c', 'text'] == repeat('a', (3 * 2) + (3 * 2) * 3)
+    assert da['@cc', 'text'] == repeat('a', 3 * 5 * 3)
+    assert da['@cc,m', 'text'] == repeat('a', 3 * 5 * 3 + 3 * 7)
+    assert da['@r:1cc,m', 'text'] == repeat('a', 1 * 5 * 3 + 3 * 7)
+    assert da[0, 'text'] == 'a'
+    assert da[[True for _ in da], 'text'] == repeat('a', 3)
+
+    da['@m,cc', 'text'] = repeat('b', 3 + 5 * 3 + 7 * 3 + 3 * 5 * 3)
+
+    assert da['@c', 'text'] == repeat('a', 3 * 5)
+    assert da['@c:1', 'text'] == repeat('a', 3)
+    assert da['@c-1:', 'text'] == repeat('a', 3)
+    assert da['@c1', 'text'] == repeat('a', 3)
+    assert da['@c-2:', 'text'] == repeat('a', 3 * 2)
+    assert da['@c1:3', 'text'] == repeat('a', 3 * 2)
+    assert da['@c1:3c', 'text'] == repeat('b', (3 * 2) * 3)
+    assert da['@c1:3,c1:3c', 'text'] == repeat('a', (3 * 2)) + repeat('b', (3 * 2) * 3)
+    assert da['@c 1:3 , c 1:3 c', 'text'] == repeat('a', (3 * 2)) + repeat(
+        'b', (3 * 2) * 3
+    )
+    assert da['@cc', 'text'] == repeat('b', 3 * 5 * 3)
+    assert da['@cc,m', 'text'] == repeat('b', 3 * 5 * 3 + 3 * 7)
+    assert da['@r:1cc,m', 'text'] == repeat('b', 1 * 5 * 3 + 3 * 7)
+    assert da[0, 'text'] == 'a'
+    assert da[[True for _ in da], 'text'] == repeat('a', 3)
+
+    da[1, 'text'] = 'd'
+    assert da[1, 'text'] == 'd'
+    assert da[1].text == 'd'
+
+    doc_id = da[0].id
+    da[doc_id, 'text'] = 'e'
+    assert da[doc_id, 'text'] == 'e'
+    assert da[doc_id].text == 'e'
+
+    # TODO also test cases like da[1, ['text', 'id']],
+    # where first index is str/int and second is attr
+
+
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_attribute_indexing(storage, start_weaviate):
     da = DocumentArray(storage=storage)
     da.extend(DocumentArray.empty(10))
 
@@ -218,8 +285,7 @@ def test_attribute_indexing(storage):
             assert vv
 
 
-# TODO: enable weaviate storage test
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
 def test_tensor_attribute_selector(storage):
     import scipy.sparse
 
@@ -246,6 +312,9 @@ def test_tensor_attribute_selector(storage):
     assert isinstance(v1, list)
 
 
+# TODO: since match function is not implemented, this test will
+# not work with weaviate storage atm, will be addressed in
+# next version
 @pytest.mark.parametrize('storage', ['memory', 'sqlite'])
 def test_advance_selector_mixed(storage):
     da = DocumentArray(storage=storage)
@@ -258,7 +327,7 @@ def test_advance_selector_mixed(storage):
     assert len(da[:, ('id', 'embedding', 'matches')][0]) == 10
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
 def test_single_boolean_and_padding(storage):
     da = DocumentArray(storage=storage)
     da.extend(DocumentArray.empty(3))
@@ -276,8 +345,8 @@ def test_single_boolean_and_padding(storage):
     assert len(da[False, False]) == 0
 
 
-@pytest.mark.parametrize('storage', ['memory', 'sqlite'])
-def test_edge_case_two_strings(storage):
+@pytest.mark.parametrize('storage', ['memory', 'sqlite', 'weaviate'])
+def test_edge_case_two_strings(storage, start_weaviate):
     # getitem
     da = DocumentArray(
         [Document(id='1'), Document(id='2'), Document(id='3')], storage=storage
@@ -303,6 +372,12 @@ def test_edge_case_two_strings(storage):
     assert len(da) == 3
     assert not da[1].text
 
+    if storage == 'weaviate':
+        with pytest.raises(
+            ValueError, match='pop id from Document stored with weaviate is not allowed'
+        ):
+            del da['1', 'id']
+
     del da['2', 'hello']
 
     # setitem
@@ -317,6 +392,7 @@ def test_edge_case_two_strings(storage):
         [Document(id='1'), Document(id='2'), Document(id='3')], storage=storage
     )
     da['1', 'text'] = 'hello'
+    assert da['1', 'text'] == 'hello'
     assert da['1'].text == 'hello'
 
     with pytest.raises(ValueError):

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -1,10 +1,24 @@
 import pytest
 
-from docarray import Document, DocumentArray
+from docarray import Document
+
+from docarray.array.memory import DocumentArrayInMemory
+from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
-def test_construct_docarray(da_cls):
+def test_construct_docarray_weaviate():
+    daw = DocumentArrayWeaviate()
+    daw.extend([Document(text='a'), Document(text='b'), Document(text='c')])
+    array_id = daw.array_id
+    del daw
+
+    daw2 = DocumentArrayWeaviate(config=WeaviateConfig(array_id=array_id))
+    assert len(daw2) == 3
+    assert daw2.texts == ['a', 'b', 'c']
+
+
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_construct_docarray(da_cls, start_weaviate):
     da = da_cls()
     assert len(da) == 0
 
@@ -20,11 +34,12 @@ def test_construct_docarray(da_cls):
     da = da_cls((Document() for _ in range(10)))
     assert len(da) == 10
 
-    da1 = da_cls(da)
-    assert len(da1) == 10
+    if da_cls is DocumentArrayInMemory:
+        da1 = da_cls(da)
+        assert len(da1) == 10
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory])
 @pytest.mark.parametrize('is_copy', [True, False])
 def test_docarray_copy_singleton(da_cls, is_copy):
     d = Document()
@@ -36,7 +51,7 @@ def test_docarray_copy_singleton(da_cls, is_copy):
         assert da[0].id == 'hello'
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory])
 @pytest.mark.parametrize('is_copy', [True, False])
 def test_docarray_copy_da(da_cls, is_copy):
     d1 = Document()
@@ -49,7 +64,7 @@ def test_docarray_copy_da(da_cls, is_copy):
         assert da[0].id == 'hello'
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory])
 @pytest.mark.parametrize('is_copy', [True, False])
 def test_docarray_copy_list(da_cls, is_copy):
     d1 = Document()

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -9,10 +9,10 @@ from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 def test_construct_docarray_weaviate(start_weaviate):
     daw = DocumentArrayWeaviate()
     daw.extend([Document(text='a'), Document(text='b'), Document(text='c')])
-    array_id = daw.array_id
+    name = daw.name
     del daw
 
-    daw2 = DocumentArrayWeaviate(config=WeaviateConfig(array_id=array_id))
+    daw2 = DocumentArrayWeaviate(config=WeaviateConfig(name=name))
     assert len(daw2) == 3
     assert daw2.texts == ['a', 'b', 'c']
 

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -6,7 +6,7 @@ from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
-def test_construct_docarray_weaviate():
+def test_construct_docarray_weaviate(start_weaviate):
     daw = DocumentArrayWeaviate()
     daw.extend([Document(text='a'), Document(text='b'), Document(text='c')])
     array_id = daw.array_id

--- a/tests/unit/array/test_sequence.py
+++ b/tests/unit/array/test_sequence.py
@@ -1,10 +1,12 @@
 import pytest
 
-from docarray import Document, DocumentArray
+from docarray import Document
+from docarray.array.memory import DocumentArrayInMemory
+from docarray.array.weaviate import DocumentArrayWeaviate
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
-def test_insert(da_cls):
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_insert(da_cls, start_weaviate):
     da = da_cls()
     assert not len(da)
     da.insert(0, Document(text='hello'))
@@ -14,8 +16,8 @@ def test_insert(da_cls):
     assert da[1].text == 'hello'
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArray])
-def test_append_extend(da_cls):
+@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArrayWeaviate])
+def test_append_extend(da_cls, start_weaviate):
     da = da_cls()
     da.append(Document())
     da.append(Document())


### PR DESCRIPTION
To better keep track of the TODO items, I have compiled the TODOs from the code into the following summary:

- Investigate into get/set attribute support (e.g. `da[1, ['text', 'id']]`)
- Clarify, Investigate and refactor the current set attribute logic
- Add test coverage for `AllMixin`
- Combine DocumentArray and its meta object into one single schema
- Investigate and use/test base class' `_set_doc_value_pairs`; add test coverage
- Currently, `vectorIndexConfig` is disabled to allow docs with no embeddings to be added. But this needs to change as it also disables vector search functionality.  Will stay tuned and address this in the next step.
- Add match function

This PR incorporated some previous changes from @alaeddine-13  on test setup and also some initial suggestions from @numb3r3. Thanks for the feedback.
