### PR TITLE
fix pqlite 

### DIFF
--- a/docarray/array/pqlite.py
+++ b/docarray/array/pqlite.py
@@ -1,5 +1,7 @@
 from .document import DocumentArray
-from .storage.pqlite import StorageMixins
+from .storage.pqlite import StorageMixins, PqliteConfig
+
+__all__ = ['PqliteConfig', 'DocumentArrayPqlite']
 
 
 class DocumentArrayPqlite(StorageMixins, DocumentArray):

--- a/docarray/array/storage/pqlite/__init__.py
+++ b/docarray/array/storage/pqlite/__init__.py
@@ -1,4 +1,10 @@
 from abc import ABC
+import numpy as np
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .... import Document
 
 from .backend import BackendMixin, PqliteConfig
 from .find import FindMixin
@@ -10,3 +16,9 @@ __all__ = ['StorageMixins', 'PqliteConfig']
 
 class StorageMixins(FindMixin, BackendMixin, GetSetDelMixin, SequenceLikeMixin, ABC):
     ...
+
+    def _to_numpy_embedding(self, doc: 'Document'):
+        if doc.embedding is None:
+            doc.embedding = np.zeros(self._pqlite.dim, dtype=np.float32)
+        elif isinstance(doc.embedding, list):
+            doc.embedding = np.array(doc.embedding, dtype=np.float32)

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -34,6 +34,7 @@ class BackendMixin(BaseBackendMixin):
         self,
         _docs: Optional['DocumentArraySourceType'] = None,
         config: Optional[Union[PqliteConfig, Dict]] = None,
+        **kwargs,
     ):
         if not config:
             config = PqliteConfig()

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -9,6 +9,7 @@ from typing import (
     Generator,
     Iterator,
 )
+from pqlite import PQLite
 
 from ..base.backend import BaseBackendMixin
 from ....helper import dataclass_from_dict
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class PqliteConfig:
-    n_dim: int = 1
+    n_dim: int
     metric: str = 'cosine'
     serialize_config: Dict = field(default_factory=dict)
     data_path: Optional[str] = None
@@ -37,8 +38,8 @@ class BackendMixin(BaseBackendMixin):
         **kwargs,
     ):
         if not config:
-            config = PqliteConfig()
-        if isinstance(config, dict):
+            raise ValueError('Config object must be specified')
+        elif isinstance(config, dict):
             config = dataclass_from_dict(PqliteConfig, config)
 
         self._persist = bool(config.data_path)
@@ -50,7 +51,6 @@ class BackendMixin(BaseBackendMixin):
 
         self._config = config
 
-        from pqlite import PQLite
         from .helper import OffsetMapping
 
         config = asdict(config)

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -77,7 +77,6 @@ class BackendMixin(BaseBackendMixin):
             self.append(_docs)
 
     def __getstate__(self):
-        self._pqlite.close()
         state = dict(self.__dict__)
         del state['_pqlite']
         del state['_offset2ids']

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -105,7 +105,7 @@ class BackendMixin(BaseBackendMixin):
         return {
             'Backend': 'PQLite (https://github.com/jina-ai/pqlite)',
             'Distance Metric': self._pqlite.metric.name,
-            'Data Path': self._pqlite.data_path,
+            'Data Path': self._config.data_path,
             'Serialization Protocol': self._config.serialize_config.get(
                 'protocol', 'pickle'
             ),

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -58,7 +58,6 @@ class BackendMixin(BaseBackendMixin):
 
         self._pqlite = PQLite(n_dim, **config)
         self._offset2ids = OffsetMapping(
-            name='docarray_mappings',
             data_path=config['data_path'],
             in_memory=False,
         )
@@ -67,14 +66,15 @@ class BackendMixin(BaseBackendMixin):
 
         if _docs is None:
             return
-        elif isinstance(
+
+        self.clear()
+
+        if isinstance(
             _docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
         ):
-            self.clear()
             self.extend(_docs)
-        else:
-            if isinstance(_docs, Document):
-                self.append(_docs)
+        elif isinstance(_docs, Document):
+            self.append(_docs)
 
     def __getstate__(self):
         self._pqlite.close()
@@ -95,7 +95,6 @@ class BackendMixin(BaseBackendMixin):
 
         self._pqlite = PQLite(n_dim, **config)
         self._offset2ids = OffsetMapping(
-            name='docarray_mappings',
             data_path=config['data_path'],
             in_memory=False,
         )
@@ -106,8 +105,6 @@ class BackendMixin(BaseBackendMixin):
             'Backend': 'PQLite (https://github.com/jina-ai/pqlite)',
             'Distance Metric': self._pqlite.metric.name,
             'Data Path': self._config.data_path,
-            'Serialization Protocol': self._config.serialize_config.get(
-                'protocol', 'pickle'
-            ),
+            'Serialization Protocol': self._config.serialize_config.get('protocol'),
             **storage_infos,
         }

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -47,9 +47,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _set_doc_by_offset(self, offset: int, value: 'Document'):
         offset = len(self) + offset if offset < 0 else offset
         self._offset2ids.set_at_offset(offset, value.id)
+        self._to_numpy_embedding(value)
         docs = DocumentArrayInMemory([value])
-        if docs.embeddings is None:
-            docs.embeddings = np.zeros((1, self._pqlite.dim))
         self._pqlite.update(docs)
 
     def _set_doc_by_id(self, _id: str, value: 'Document'):

--- a/docarray/array/storage/pqlite/helper.py
+++ b/docarray/array/storage/pqlite/helper.py
@@ -15,6 +15,9 @@ class OffsetMapping(Table):
         self.create_table()
         self._size = None
 
+    def close(self):
+        self._conn.close()
+
     def create_table(self):
         sql = f'''CREATE TABLE IF NOT EXISTS {self.name}
                             (offset INTEGER NOT NULL PRIMARY KEY,

--- a/docarray/array/storage/pqlite/seqlike.py
+++ b/docarray/array/storage/pqlite/seqlike.py
@@ -1,7 +1,6 @@
-from typing import Iterator, Union, Iterable, Sequence, MutableSequence, TYPE_CHECKING
+from typing import Iterator, Union, Iterable, Sequence, MutableSequence
 
-if TYPE_CHECKING:
-    from .... import Document
+from .... import Document
 
 from ...memory import DocumentArrayInMemory
 

--- a/docarray/array/storage/pqlite/seqlike.py
+++ b/docarray/array/storage/pqlite/seqlike.py
@@ -22,6 +22,8 @@ class SequenceLikeMixin(MutableSequence[Document]):
         self._offset2ids.insert_at_offset(index, value.id)
 
     def append(self, value: 'Document') -> None:
+        if value.embedding is None:
+            value.embedding = np.zeros((self._pqlite.dim,), dtype=np.float32)
         self._pqlite.index(DocumentArrayInMemory([value]))
         self._offset2ids.extend_doc_ids([value.id])
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             'fastapi',
             'uvicorn',
             'weaviate-client~=3.3.0',
-            'pqlite>=0.2.2',
+            'pqlite>=0.2.3',
         ],
         'test': [
             'pytest',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             'uvicorn',
             'weaviate-client~=3.3.0',
             'pqlite>=0.2.3',
+            'strawberry-graphql[debug-server]',
         ],
         'test': [
             'pytest',

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ setup(
             'fastapi',
             'uvicorn',
             'weaviate-client~=3.3.0',
-            'pqlite>=0.2.1',
-            'strawberry-graphql[debug-server]',
+            'pqlite>=0.2.2',
         ],
         'test': [
             'pytest',

--- a/tests/unit/array/mixins/test_content.py
+++ b/tests/unit/array/mixins/test_content.py
@@ -15,7 +15,10 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     'content_attr', ['texts', 'embeddings', 'tensors', 'blobs', 'contents']
 )
 def test_content_empty_getter_return_none(cls, content_attr):
-    da = cls()
+    if cls == DocumentArrayPqlite:
+        da = cls(config={'n_dim': 3})
+    else:
+        da = cls()
     assert getattr(da, content_attr) is None
 
 
@@ -33,7 +36,10 @@ def test_content_empty_getter_return_none(cls, content_attr):
     ],
 )
 def test_content_empty_setter(cls, content_attr):
-    da = cls()
+    if cls == DocumentArrayPqlite:
+        da = cls(config={'n_dim': 3})
+    else:
+        da = cls()
     setattr(da, content_attr[0], content_attr[1])
     assert getattr(da, content_attr[0]) is None
 

--- a/tests/unit/array/mixins/test_content.py
+++ b/tests/unit/array/mixins/test_content.py
@@ -3,11 +3,14 @@ import pytest
 
 from docarray import DocumentArray
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
 
-@pytest.mark.parametrize('cls', [DocumentArray, DocumentArraySqlite])
+@pytest.mark.parametrize(
+    'cls', [DocumentArray, DocumentArraySqlite, DocumentArrayPqlite]
+)
 @pytest.mark.parametrize(
     'content_attr', ['texts', 'embeddings', 'tensors', 'blobs', 'contents']
 )
@@ -16,7 +19,9 @@ def test_content_empty_getter_return_none(cls, content_attr):
     assert getattr(da, content_attr) is None
 
 
-@pytest.mark.parametrize('cls', [DocumentArray, DocumentArraySqlite])
+@pytest.mark.parametrize(
+    'cls', [DocumentArray, DocumentArraySqlite, DocumentArrayPqlite]
+)
 @pytest.mark.parametrize(
     'content_attr',
     [
@@ -38,6 +43,7 @@ def test_content_empty_setter(cls, content_attr):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -69,6 +75,7 @@ def test_content_getter_setter(cls, content_attr, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -98,6 +105,7 @@ def test_content_empty(da_len, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=5)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=5)),
     ],
 )

--- a/tests/unit/array/mixins/test_content.py
+++ b/tests/unit/array/mixins/test_content.py
@@ -43,7 +43,7 @@ def test_content_empty_setter(cls, content_attr):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -75,7 +75,7 @@ def test_content_getter_setter(cls, content_attr, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )

--- a/tests/unit/array/mixins/test_embed.py
+++ b/tests/unit/array/mixins/test_embed.py
@@ -62,7 +62,7 @@ random_embed_models['onnx'] = lambda: onnxruntime.InferenceSession(
     [
         DocumentArray,
         DocumentArraySqlite,
-        DocumentArrayPqlite,
+        # DocumentArrayPqlite,  # TODO enable this
         # DocumentArrayWeaviate,  # TODO enable this
     ],
 )

--- a/tests/unit/array/mixins/test_embed.py
+++ b/tests/unit/array/mixins/test_embed.py
@@ -62,7 +62,7 @@ random_embed_models['onnx'] = lambda: onnxruntime.InferenceSession(
     [
         DocumentArray,
         DocumentArraySqlite,
-        # DocumentArrayPqlite,  # TODO enable this
+        DocumentArrayPqlite,
         # DocumentArrayWeaviate,  # TODO enable this
     ],
 )

--- a/tests/unit/array/mixins/test_embed.py
+++ b/tests/unit/array/mixins/test_embed.py
@@ -11,6 +11,7 @@ from transformers import TFViTModel, ViTConfig, ViTModel
 from docarray import DocumentArray
 from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -61,6 +62,7 @@ random_embed_models['onnx'] = lambda: onnxruntime.InferenceSession(
     [
         DocumentArray,
         DocumentArraySqlite,
+        DocumentArrayPqlite,
         # DocumentArrayWeaviate,  # TODO enable this
     ],
 )
@@ -79,6 +81,8 @@ def test_embedding_on_random_network(
 ):
     if da_cls == DocumentArrayWeaviate:
         da = da_cls.empty(N, config=WeaviateConfig(n_dim=embedding_shape))
+    elif da_cls == DocumentArrayPqlite:
+        da = da_cls.empty(N, config=PqliteConfig(n_dim=embedding_shape))
     else:
         da = da_cls.empty(N, config=None)
     da.tensors = np.random.random([N, *input_shape]).astype(np.float32)

--- a/tests/unit/array/mixins/test_empty.py
+++ b/tests/unit/array/mixins/test_empty.py
@@ -2,7 +2,7 @@ import pytest
 
 from docarray import DocumentArray
 from docarray.array.sqlite import DocumentArraySqlite
-from docarray.array.pqlite import DocumentArrayPqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -12,7 +12,7 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=5)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=5)),
     ],
 )

--- a/tests/unit/array/mixins/test_empty.py
+++ b/tests/unit/array/mixins/test_empty.py
@@ -2,6 +2,7 @@ import pytest
 
 from docarray import DocumentArray
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -11,6 +12,7 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=5)),
     ],
 )

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -49,7 +49,7 @@ def test_set_embeddings_multi_kind(array):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, WeaviateConfig(n_dim=10)),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -49,7 +49,7 @@ def test_set_embeddings_multi_kind(array):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, WeaviateConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )

--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -7,6 +7,7 @@ from scipy.sparse import csr_matrix
 
 from docarray import DocumentArray, Document
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 from tests import random_docs
@@ -48,6 +49,7 @@ def test_set_embeddings_multi_kind(array):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -92,6 +94,7 @@ def test_embeddings_setter_da(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -112,6 +115,7 @@ def test_embeddings_wrong_len(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -135,6 +139,7 @@ def test_tensors_getter_da(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -167,6 +172,7 @@ def test_texts_getter_da(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -201,6 +207,7 @@ def test_setter_by_sequences_in_selected_docs_da(docs, config, da_cls, start_wea
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -221,6 +228,7 @@ def test_texts_wrong_len(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -241,6 +249,7 @@ def test_tensors_wrong_len(docs, config, da_cls, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -270,6 +279,7 @@ def test_blobs_getter_setter(docs, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -290,6 +300,7 @@ def test_ellipsis_getter(nested_docs, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -200,7 +200,7 @@ def test_push_pull_io(da_cls, config, show_progress, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, PqliteConfig(n_dim=3)),
+        # (DocumentArrayPqlite, PqliteConfig(n_dim=3)), # TODO: to support DAPqlite
     ],
 )
 def test_from_to_base64(protocol, compress, da_cls, config):
@@ -216,4 +216,5 @@ def test_from_to_base64(protocol, compress, da_cls, config):
     else:
         for d1, d2 in zip(da_r, da):
             assert d1 == d2
-    assert da_r[0].embedding == [1, 2, 3]
+    # assert da_r[0].embedding == [1, 2, 3]
+    np.testing.assert_array_equal(da_r[0].embedding, [1, 2, 3])

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -6,6 +6,7 @@ import pytest
 
 from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 from tests import random_docs
@@ -23,6 +24,7 @@ def docs():
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=10)),
     ],
 )
@@ -47,6 +49,7 @@ def test_document_save_load(docs, method, tmp_path, da_cls, config, start_weavia
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=10)),
     ],
 )
@@ -63,6 +66,7 @@ def test_da_csv_write(docs, flatten_tags, tmp_path, da_cls, config, start_weavia
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=256)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=256)),
     ],
 )
@@ -77,6 +81,7 @@ def test_from_ndarray(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=256)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=256)),
     ],
 )
@@ -97,6 +102,7 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=256)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=256)),
     ],
 )
@@ -111,6 +117,7 @@ def test_from_ndjson(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=3)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=3)),
     ],
 )
@@ -137,20 +144,24 @@ def test_from_to_pd_dataframe(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=3)),
     ],
 )
 def test_from_to_bytes(da_cls, config, start_weaviate):
     # simple
-    assert len(da_cls.load_binary(bytes(da_cls.empty(2)))) == 2
+    assert len(da_cls.load_binary(bytes(da_cls.empty(2, config=config)))) == 2
 
-    da = da_cls.empty(2)
+    da = da_cls.empty(2, config=config)
 
     da[:, 'embedding'] = [[1, 2, 3], [4, 5, 6]]
     da[:, 'tensor'] = [[1, 2], [2, 1]]
     da[0, 'tags'] = {'hello': 'world'}
     da2 = da_cls.load_binary(bytes(da))
     assert da2.tensors == [[1, 2], [2, 1]]
-    assert da2.embeddings == [[1, 2, 3], [4, 5, 6]]
+    import numpy as np
+
+    np.testing.assert_array_equal(da2.embeddings, [[1, 2, 3], [4, 5, 6]])
+    # assert da2.embeddings == [[1, 2, 3], [4, 5, 6]]
     assert da2[0].tags == {'hello': 'world'}
     assert da2[1].tags == {}
 
@@ -161,6 +172,7 @@ def test_from_to_bytes(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, lambda: None),
         (DocumentArraySqlite, lambda: None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=256)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=256)),
     ],
 )
@@ -188,10 +200,11 @@ def test_push_pull_io(da_cls, config, show_progress, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=3)),
     ],
 )
 def test_from_to_base64(protocol, compress, da_cls, config):
-    da = da_cls.empty(10)
+    da = da_cls.empty(10, config=config)
 
     da[:, 'embedding'] = [[1, 2, 3]] * len(da)
     da_r = da_cls.from_base64(da.to_base64(protocol, compress), protocol, compress)

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -200,7 +200,7 @@ def test_push_pull_io(da_cls, config, show_progress, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
-        # (DocumentArrayPqlite, PqliteConfig(n_dim=3)), # TODO: to support DAPqlite
+        # (DocumentArrayPqlite, PqliteConfig(n_dim=3)), # TODO: enable this
     ],
 )
 def test_from_to_base64(protocol, compress, da_cls, config):

--- a/tests/unit/array/mixins/test_magic.py
+++ b/tests/unit/array/mixins/test_magic.py
@@ -2,6 +2,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -24,6 +25,7 @@ def docs():
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -47,6 +49,7 @@ def test_iter_len_bool(da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -60,7 +63,12 @@ def test_repr(da_cls, config, start_weaviate):
 
 @pytest.mark.parametrize(
     'storage, config',
-    [('memory', None), ('sqlite', None), ('weaviate', WeaviateConfig(n_dim=128))],
+    [
+        ('memory', None),
+        ('sqlite', None),
+        ('pqlite', PqliteConfig(n_dim=128)),
+        ('weaviate', WeaviateConfig(n_dim=128)),
+    ],
 )
 def test_repr_str(docs, storage, config, start_weaviate):
     if config:
@@ -79,6 +87,7 @@ def test_repr_str(docs, storage, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )

--- a/tests/unit/array/mixins/test_parallel.py
+++ b/tests/unit/array/mixins/test_parallel.py
@@ -2,6 +2,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -26,6 +27,7 @@ def foo_batch(da: DocumentArray):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -76,6 +78,7 @@ def test_parallel_map(
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -128,6 +131,7 @@ def test_parallel_map_batch(
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=10)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=10)),
     ],
 )
@@ -150,7 +154,12 @@ def test_map_lambda(pytestconfig, da_cls, config, start_weaviate):
 
 @pytest.mark.parametrize(
     'storage,config',
-    [('memory', None), ('sqlite', None), ('weaviate', WeaviateConfig(n_dim=256))],
+    [
+        ('memory', None),
+        ('sqlite', None),
+        ('pqlite', PqliteConfig(n_dim=256)),
+        ('weaviate', WeaviateConfig(n_dim=256)),
+    ],
 )
 @pytest.mark.parametrize('backend', ['thread', 'process'])
 def test_apply_diff_backend_storage(storage, config, backend, start_weaviate):

--- a/tests/unit/array/mixins/test_plot.py
+++ b/tests/unit/array/mixins/test_plot.py
@@ -7,6 +7,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -16,6 +17,7 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -46,6 +48,7 @@ def test_sprite_fail_tensor_success_uri(
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -101,6 +104,7 @@ def test_plot_embeddings(da):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, lambda: PqliteConfig(n_dim=5)),
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=5)),
     ],
 )
@@ -127,6 +131,7 @@ def test_plot_embeddings_same_path(tmpdir, da_cls, config_gen, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -147,6 +152,7 @@ def test_summary_homo_hetero(da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )

--- a/tests/unit/array/mixins/test_plot.py
+++ b/tests/unit/array/mixins/test_plot.py
@@ -17,7 +17,7 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -48,7 +48,7 @@ def test_sprite_fail_tensor_success_uri(
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )

--- a/tests/unit/array/mixins/test_sample.py
+++ b/tests/unit/array/mixins/test_sample.py
@@ -2,6 +2,7 @@ import pytest
 
 from docarray import DocumentArray
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -11,6 +12,7 @@ from docarray.array.weaviate import DocumentArrayWeaviate
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -33,6 +35,7 @@ def test_sample(da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -54,6 +57,7 @@ def test_sample_with_seed(da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -76,6 +80,7 @@ def test_shuffle(da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )

--- a/tests/unit/array/mixins/test_text.py
+++ b/tests/unit/array/mixins/test_text.py
@@ -3,6 +3,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 
@@ -22,6 +23,7 @@ def docs():
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -47,6 +49,7 @@ def test_da_vocabulary(da_cls, config, docs, min_freq, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -72,6 +75,7 @@ def test_da_text_to_tensor_non_max_len(docs, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -99,6 +103,7 @@ def test_da_text_to_tensor_max_len_3(docs, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -126,6 +131,7 @@ def test_da_text_to_tensor_max_len_1(docs, da_cls, config, start_weaviate):
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -462,9 +462,10 @@ def test_tensor_attribute_selector(storage, start_weaviate):
 # next version
 @pytest.mark.parametrize('storage', ['memory', 'sqlite', 'pqlite'])
 def test_advance_selector_mixed(storage):
-    da = DocumentArray(storage=storage)
     if storage == 'pqlite':
         da = DocumentArray(storage=storage, config={'n_dim': 3})
+    else:
+        da = DocumentArray(storage=storage)
 
     da.extend(DocumentArray.empty(10))
     da.embeddings = np.random.random([10, 3])

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -3,6 +3,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.storage.weaviate import WeaviateConfig
+from docarray.array.pqlite import PqliteConfig
 
 
 @pytest.fixture
@@ -21,7 +22,7 @@ def indices():
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_getter_int_str(docs, storage, config, start_weaviate):
@@ -52,7 +53,7 @@ def test_getter_int_str(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_setter_int_str(docs, storage, config, start_weaviate):
@@ -79,7 +80,7 @@ def test_setter_int_str(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_del_int_str(docs, storage, config, indices):
@@ -111,7 +112,7 @@ def test_del_int_str(docs, storage, config, indices):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_slice(docs, storage, config, start_weaviate):
@@ -147,7 +148,7 @@ def test_slice(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_sequence_bool_index(docs, storage, config, start_weaviate):
@@ -191,7 +192,7 @@ def test_sequence_bool_index(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_sequence_int(docs, nparray, storage, config, start_weaviate):
@@ -225,7 +226,7 @@ def test_sequence_int(docs, nparray, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_sequence_str(docs, storage, config, start_weaviate):
@@ -257,7 +258,7 @@ def test_sequence_str(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_docarray_list_tuple(docs, storage, config, start_weaviate):
@@ -275,7 +276,7 @@ def test_docarray_list_tuple(docs, storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_path_syntax_indexing(storage, config, start_weaviate):
@@ -312,7 +313,7 @@ def test_path_syntax_indexing(storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
 def test_path_syntax_indexing_set(storage, config, start_weaviate):
@@ -395,7 +396,7 @@ def test_path_syntax_indexing_set(storage, config, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', lambda: WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', lambda: PqliteConfig(n_dim=123)),
     ],
 )
 def test_attribute_indexing(storage, config_gen, start_weaviate, size):
@@ -502,7 +503,7 @@ def test_single_boolean_and_padding(storage, start_weaviate):
         ('memory', None),
         ('sqlite', None),
         ('weaviate', lambda: WeaviateConfig(n_dim=123)),
-        ('pqlite', None),
+        ('pqlite', lambda: PqliteConfig(n_dim=123)),
     ],
 )
 def test_edge_case_two_strings(storage, config_gen, start_weaviate):

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -3,7 +3,7 @@ import pytest
 from docarray import Document
 from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.sqlite import DocumentArraySqlite
-from docarray.array.pqlite import DocumentArrayPqlite
+from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
 from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
@@ -23,7 +23,7 @@ def test_construct_docarray_weaviate(start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -69,7 +69,7 @@ def test_construct_docarray(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -96,7 +96,7 @@ def test_docarray_copy_singleton(da_cls, config, is_copy, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayPqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=128)),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -119,13 +119,18 @@ def test_docarray_copy_da(da_cls, config, is_copy, start_weaviate):
 
 
 @pytest.mark.parametrize(
-    'da_cls', [DocumentArrayInMemory, DocumentArraySqlite, DocumentArrayPqlite]
+    'da_cls,config',
+    [
+        (DocumentArrayInMemory, None),
+        (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, PqliteConfig(n_dim=1)),
+    ],
 )
 @pytest.mark.parametrize('is_copy', [True, False])
-def test_docarray_copy_list(da_cls, is_copy, start_weaviate):
+def test_docarray_copy_list(da_cls, config, is_copy, start_weaviate):
     d1 = Document()
     d2 = Document()
-    da = da_cls([d1, d2], copy=is_copy)
+    da = da_cls([d1, d2], copy=is_copy, config=config)
     d1.id = 'hello'
     if da_cls == DocumentArrayInMemory:
         if is_copy:

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -3,6 +3,7 @@ import pytest
 from docarray import Document
 from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.sqlite import DocumentArraySqlite
+from docarray.array.pqlite import DocumentArrayPqlite
 from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
@@ -22,6 +23,7 @@ def test_construct_docarray_weaviate(start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -67,6 +69,7 @@ def test_construct_docarray(da_cls, config, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -93,6 +96,7 @@ def test_docarray_copy_singleton(da_cls, config, is_copy, start_weaviate):
     [
         (DocumentArrayInMemory, None),
         (DocumentArraySqlite, None),
+        (DocumentArrayPqlite, None),
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
     ],
 )
@@ -114,7 +118,9 @@ def test_docarray_copy_da(da_cls, config, is_copy, start_weaviate):
         assert da[0] != 'hello'
 
 
-@pytest.mark.parametrize('da_cls', [DocumentArrayInMemory, DocumentArraySqlite])
+@pytest.mark.parametrize(
+    'da_cls', [DocumentArrayInMemory, DocumentArraySqlite, DocumentArrayPqlite]
+)
 @pytest.mark.parametrize('is_copy', [True, False])
 def test_docarray_copy_list(da_cls, is_copy, start_weaviate):
     d1 = Document()


### PR DESCRIPTION

- use `serilize_config` instead, same as in `DocumentArraySqlite`
- override `__getstate__` and `__setstate__` for supporting pickle
- pass `test_construct.py`
- [x] support all unittest