### PR TITLE
fix: weaviate da del behavior

### DIFF
--- a/docarray/array/storage/registry.py
+++ b/docarray/array/storage/registry.py
@@ -1,0 +1,4 @@
+from collections import defaultdict
+
+
+_REGISTRY = defaultdict(lambda: defaultdict(list))

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -19,6 +19,7 @@ import weaviate
 from ..base.backend import BaseBackendMixin
 from .... import Document
 from ....helper import dataclass_from_dict
+from ..registry import _REGISTRY
 
 if TYPE_CHECKING:
     from ....types import (
@@ -66,7 +67,10 @@ class BackendMixin(BaseBackendMixin):
         self._serialize_config = config.serialize_config
 
         if config.name and config.name != config.name.capitalize():
-            raise ValueError('weaviate class name has to be capitalized')
+            raise ValueError(
+                'Weaviate class name has to be capitalized. '
+                'Please capitalize when declaring the name field in config.'
+            )
 
         self._persist = bool(config.name)
 
@@ -79,6 +83,7 @@ class BackendMixin(BaseBackendMixin):
         self._schemas = self._load_or_create_weaviate_schema()
         self._offset2ids, self._offset2ids_wid = self._get_offset2ids_meta()
 
+        _REGISTRY[self.__class__.__name__][self._class_name].append(self)
         # To align with Sqlite behavior; if `docs` is not `None` and table name
         # is provided, :class:`DocumentArraySqlite` will clear the existing
         # table and load the given `docs`

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -65,6 +65,11 @@ class BackendMixin(BaseBackendMixin):
         self._n_dim = config.n_dim
         self._serialize_config = config.serialize_config
 
+        if config.name and config.name != config.name.capitalize():
+            raise ValueError('weaviate class name has to be capitalized')
+
+        self._persist = bool(config.name)
+
         if isinstance(config.client, str):
             self._client = weaviate.Client(config.client)
         else:

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -70,6 +70,12 @@ class SequenceLikeMixin(MutableSequence[Document]):
         else:
             return False
 
+    def __del__(self):
+        """Delete this :class:`DocumentArrayWeaviate` object"""
+        if not self._persist:
+            self._client.schema.delete_class(self._class_name)
+            self._client.schema.delete_class(self._meta_name)
+
     def clear(self):
         """Clear the data of :class:`DocumentArray` with weaviate storage"""
         self._del_all_docs()

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -1,6 +1,7 @@
 from typing import Iterator, Union, Iterable, MutableSequence
 
 from .... import Document
+from ..registry import _REGISTRY
 
 
 class SequenceLikeMixin(MutableSequence[Document]):
@@ -72,9 +73,13 @@ class SequenceLikeMixin(MutableSequence[Document]):
 
     def __del__(self):
         """Delete this :class:`DocumentArrayWeaviate` object"""
-        if not self._persist:
+        if (
+            not self._persist
+            and len(_REGISTRY[self.__class__.__name__][self._class_name]) == 1
+        ):
             self._client.schema.delete_class(self._class_name)
             self._client.schema.delete_class(self._meta_name)
+        _REGISTRY[self.__class__.__name__][self._class_name].remove(self)
 
     def clear(self):
         """Clear the data of :class:`DocumentArray` with weaviate storage"""

--- a/tests/unit/array/mixins/test_del.py
+++ b/tests/unit/array/mixins/test_del.py
@@ -1,6 +1,7 @@
 import pytest
 
 from docarray import DocumentArray, Document
+from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
 @pytest.fixture()
@@ -40,3 +41,21 @@ def test_del_all(docs, to_delete):
 def test_del_by_multiple_idx(docs, deleted_ids, expected_ids):
     del docs[deleted_ids]
     assert docs[:, 'id'] == expected_ids
+
+
+@pytest.mark.parametrize(
+    'da_cls,config_cls,kwargs,persist',
+    [
+        (DocumentArrayWeaviate, WeaviateConfig, {'n_dim': 10}, False),
+        (DocumentArrayWeaviate, WeaviateConfig, {'name': 'Storage', 'n_dim': 10}, True),
+    ],
+)
+def test_del_da_persist(da_cls, config_cls, kwargs, persist, docs, start_weaviate):
+    da = da_cls(docs, config=config_cls(**kwargs))
+    del da
+
+    da2 = da_cls(config=config_cls(**kwargs))
+    if persist:
+        assert len(da2) == len(docs)
+    else:
+        assert len(da2) == 0

--- a/tests/unit/array/mixins/test_del.py
+++ b/tests/unit/array/mixins/test_del.py
@@ -1,7 +1,7 @@
 import pytest
 
 from docarray import DocumentArray, Document
-from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
+from docarray.array.weaviate import DocumentArrayWeaviate
 
 
 @pytest.fixture()
@@ -44,17 +44,17 @@ def test_del_by_multiple_idx(docs, deleted_ids, expected_ids):
 
 
 @pytest.mark.parametrize(
-    'da_cls,config_cls,kwargs,persist',
+    'da_cls,config,persist',
     [
-        (DocumentArrayWeaviate, WeaviateConfig, {'n_dim': 10}, False),
-        (DocumentArrayWeaviate, WeaviateConfig, {'name': 'Storage', 'n_dim': 10}, True),
+        (DocumentArrayWeaviate, {'n_dim': 10}, False),
+        (DocumentArrayWeaviate, {'name': 'Storage', 'n_dim': 10}, True),
     ],
 )
-def test_del_da_persist(da_cls, config_cls, kwargs, persist, docs, start_weaviate):
-    da = da_cls(docs, config=config_cls(**kwargs))
+def test_del_da_persist(da_cls, config, persist, docs, start_weaviate):
+    da = da_cls(docs, config=config)
     del da
 
-    da2 = da_cls(config=config_cls(**kwargs))
+    da2 = da_cls(config=config)
     if persist:
         assert len(da2) == len(docs)
     else:

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -6,17 +6,6 @@ from docarray.array.sqlite import DocumentArraySqlite
 from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 
 
-def test_construct_docarray_weaviate(start_weaviate):
-    daw = DocumentArrayWeaviate(config=WeaviateConfig(n_dim=10))
-    daw.extend([Document(text='a'), Document(text='b'), Document(text='c')])
-    name = daw.name
-    del daw
-
-    daw2 = DocumentArrayWeaviate(config=WeaviateConfig(n_dim=10, name=name))
-    assert len(daw2) == 3
-    assert daw2.texts == ['a', 'b', 'c']
-
-
 @pytest.mark.parametrize(
     'da_cls,config',
     [


### PR DESCRIPTION
Align the del/destructor behavior of `DocumentArrayWeaviate` with `DocumentArraySqlite` (delete data only when `self._persist` is `True`, that is when table name/name in provided in `config`).

Also, adding a check to assert `name` provided is capitalized. This is because if `name` is not capitalized, Weaviate will automatically capitalize the name but users may not be aware of this special case.
