### PR TITLE
feat: integrate match and find function

### DIFF
--- a/docarray/array/mixins/__init__.py
+++ b/docarray/array/mixins/__init__.py
@@ -16,6 +16,7 @@ from .io.from_gen import FromGeneratorMixin
 from .io.json import JsonIOMixin
 from .io.pushpull import PushPullMixin
 from .match import MatchMixin
+from .find import FindMixin
 from .parallel import ParallelMixin
 from .plot import PlotMixin
 from .pydantic import PydanticMixin
@@ -44,6 +45,7 @@ class AllMixins(
     EmbedMixin,
     PushPullMixin,
     FromGeneratorMixin,
+    FindMixin,
     MatchMixin,
     TraverseMixin,
     PlotMixin,

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -3,9 +3,11 @@ from ...math.helper import top_k, minmax_normalize, update_rows_x_mat_best
 from ...score import NamedScore
 import numpy as np
 
+
 if TYPE_CHECKING:
     from ...types import T, ArrayType
-    from ... import Document, DocumentArray
+
+    # from ... import Document, DocumentArray
 
 
 class FindMixin:
@@ -33,6 +35,7 @@ class FindMixin:
         **kwargs,
     ) -> 'DocumentArray':
         from ...math.ndarray import to_numpy_array, get_array_type
+        from ... import Document, DocumentArray
 
         if isinstance(query, (dict, str)):
             return self.filter(query, **kwargs)
@@ -147,6 +150,8 @@ class FindMixin:
         else:
             dist, idx = self._search(query, cdist, _limit, normalization, metric_name)
 
+        from ... import Document, DocumentArray
+
         result = DocumentArray([Document(id=q.id) for q in query])
         for _q, _ids, _dists in zip(result, idx, dist):
             num_matches = 0
@@ -186,7 +191,7 @@ class FindMixin:
         :return: distances and indices
         """
         dists = cdist(query.embeddings, self.embeddings, metric_name)
-        dist, idx = top_k(dists, min(limit, len(query)), descending=False)
+        dist, idx = top_k(dists, min(limit, len(self)), descending=False)
         if isinstance(normalization, (tuple, list)) and normalization is not None:
             # normalization bound uses original distance not the top-k trimmed distance
             min_d = np.min(dists, axis=-1, keepdims=True)

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -1,4 +1,4 @@
-from typing import overload, Optional, Union, List, Dict, Tuple, Callable, TYPE_CHECKING
+from typing import overload, Optional, Union, Dict, Tuple, Callable, TYPE_CHECKING
 from ...math.helper import top_k, minmax_normalize, update_rows_x_mat_best
 from ...score import NamedScore
 import numpy as np
@@ -7,7 +7,7 @@ import numpy as np
 if TYPE_CHECKING:
     from ...types import T, ArrayType
 
-    # from ... import Document, DocumentArray
+    from ... import Document, DocumentArray
 
 
 class FindMixin:
@@ -31,7 +31,7 @@ class FindMixin:
 
     def find(
         self: 'T',
-        query: Union['DocumentArray', 'Document', 'ArrayType', Callable, Dict, str],
+        query: Union['DocumentArray', 'Document', 'ArrayType', Dict, str],
         **kwargs,
     ) -> 'DocumentArray':
         from ...math.ndarray import to_numpy_array, get_array_type

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -39,11 +39,6 @@ class FindMixin:
 
         if isinstance(query, (DocumentArray, Document)):
 
-            print("\n\nHEREEEE!!!!\n\n")
-            import pdb
-
-            pdb.set_trace()
-
             if isinstance(query, Document):
                 query = DocumentArray(query)
 
@@ -189,7 +184,15 @@ class FindMixin:
         :param metric_name: if provided, then match result will be marked with this string.
         :return: distances and indices
         """
-        dists = cdist(query.embeddings, self.embeddings, metric_name)
+
+        # Ensure query is a 'matrix' since cdist(X,Y) computes all pairwise distances
+        # between rows of X and rows of Y.
+        if query.embeddings.ndim != 2:
+            query_embeddings = query.embeddings.reshape(1, -1)
+        else:
+            query_embeddings = query.embeddings
+
+        dists = cdist(query_embeddings, self.embeddings, metric_name)
         dist, idx = top_k(dists, min(limit, len(self)), descending=False)
         if isinstance(normalization, (tuple, list)) and normalization is not None:
             # normalization bound uses original distance not the top-k trimmed distance

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -37,13 +37,11 @@ class FindMixin:
         from ...math import ndarray
         from ... import Document, DocumentArray
 
-        if isinstance(query, (dict, str)):
-            return self.filter(query, **kwargs)
-        elif isinstance(query, (DocumentArray, Document)):
+        if isinstance(query, (DocumentArray, Document)):
             if isinstance(query, Document):
                 query = DocumentArray(query)
 
-            result = self.search(query, **kwargs)
+            result = self._find_similar_docs(query, **kwargs)
 
             if len(query) == 1:
                 return result[0]
@@ -55,23 +53,16 @@ class FindMixin:
             q_mat = ndarray.to_numpy_array(query)
             if n_rows == 1:
                 q = DocumentArray(Document(embedding=q_mat.flatten()))
-                return self.search(q, **kwargs)[0]
+                return self._find_similar_docs(q, **kwargs)[0]
             else:
                 q = DocumentArray([Document(embedding=x) for x in q_mat])
-                return self.search(q, **kwargs)
+                return self._find_similar_docs(q, **kwargs)
         except Exception as ex:
             raise ValueError(
                 f'The find method of {self.__class__.__name__} does not support the type of query: {type(query)}'
             )
 
-    def filter(self: 'T', query: Union[Dict, str], **kwargs) -> 'DocumentArray':
-        """Returns a new DocumentArray with filtering out docs that match with the given query function.
-
-        :return: DocumentArray containing all documents matching the given `query`
-        """
-        ...
-
-    def search(
+    def _find_similar_docs(
         self: 'T',
         query: 'DocumentArray',
         metric: Union[

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -41,15 +41,20 @@ class FindMixin:
             return self.filter(query, **kwargs)
         elif isinstance(query, (DocumentArray, Document)):
             if isinstance(query, Document):
-                return self.search(DocumentArray(query), **kwargs)[0]
+                query = DocumentArray(query)
 
-            return self.search(query, **kwargs)
+            result = self.search(query, **kwargs)
+
+            if len(query) == 1:
+                return result[0]
+
+            return result
 
         try:
-            _, _ = ndarray.get_array_type(query)
+            n_rows, _ = ndarray.get_array_rows(query)
             q_mat = ndarray.to_numpy_array(query)
-            if q_mat.ndim == 1:
-                q = DocumentArray(Document(embedding=q_mat))
+            if n_rows == 1:
+                q = DocumentArray(Document(embedding=q_mat.flatten()))
                 return self.search(q, **kwargs)[0]
             else:
                 q = DocumentArray([Document(embedding=x) for x in q_mat])

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -229,13 +229,13 @@ class FindMixin:
         top_inds = np.zeros((n_q, limit), dtype=int)
 
         def _get_dist(da: 'DocumentArray'):
-            distances = cdist(query.embeddings, self.embeddings, metric_name)
+            distances = cdist(query.embeddings, da.embeddings, metric_name)
             dists, inds = top_k(distances, limit, descending=False)
 
             if isinstance(normalization, (tuple, list)) and normalization is not None:
                 dists = minmax_normalize(dists, normalization)
 
-            return dists, inds, len(self)
+            return dists, inds, len(da)
 
         if num_worker is None or num_worker > 1:
             # notice that all most all computations (regardless the framework) are conducted in C

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -31,7 +31,7 @@ class FindMixin:
 
     def find(
         self: 'T',
-        query: Union['DocumentArray', 'Document', 'ArrayType', Dict, str],
+        query: Union['DocumentArray', 'Document', 'ArrayType'],
         **kwargs,
     ) -> Union['DocumentArray', List['DocumentArray']]:
         from ...math import ndarray

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -52,11 +52,9 @@ class FindMixin:
             _, _ = ndarray.get_array_type(query)
             n_rows, _ = ndarray.get_array_rows(query)
             if n_rows == 1:
-                q = DocumentArray(Document(embedding=query))
-                return self._find_similar_docs(q, **kwargs)[0]
+                return self._find_similar_docs(query, **kwargs)[0]
             else:
-                q = DocumentArray([Document(embedding=x) for x in query])
-                return self._find_similar_docs(q, **kwargs)
+                return self._find_similar_docs(query, **kwargs)
         except TypeError:
             raise TypeError(
                 f'The find method of {self.__class__.__name__} does not support the type of query: {type(query)}'
@@ -66,7 +64,7 @@ class FindMixin:
 
     def _find_similar_docs(
         self: 'T',
-        query: 'DocumentArray',
+        query: 'np.ndarray',
         metric: Union[
             str, Callable[['ArrayType', 'ArrayType'], 'np.ndarray']
         ] = 'cosine',
@@ -83,8 +81,8 @@ class FindMixin:
     ) -> List['DocumentArray']:
         """Returns approximate nearest neighbors given a batch of input queries.
 
-        :param query: the DocumentArray to search by their embeddings.
-        :param metric: the distance metric
+        :param query: the `np.ndarray` used containing embeddings as rows.
+        :param metric: the distance metric.
         :param limit: the maximum number of matches, when not given defaults to 20.
         :param normalization: a tuple [a, b] to be used with min-max normalization,
                                 the min distance will be rescaled to `a`, the max distance will be rescaled to `b`

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -1,0 +1,263 @@
+from typing import overload, Optional, Union, List, Dict, Tuple, Callable, TYPE_CHECKING
+from ...math.helper import top_k, minmax_normalize, update_rows_x_mat_best
+from ...score import NamedScore
+import numpy as np
+
+if TYPE_CHECKING:
+    from ...types import T, ArrayType
+    from ... import Document, DocumentArray
+
+
+class FindMixin:
+    """ A mixin that provides find functionality to DocumentArrays  """
+
+    @overload
+    def find(self: 'T', query: 'ArrayType', **kwargs):
+        ...
+
+    @overload
+    def find(self: 'T', query: Union['Document', 'DocumentArray'], **kwargs):
+        ...
+
+    @overload
+    def find(self: 'T', query: Dict, **kwargs):
+        ...
+
+    @overload
+    def find(self: 'T', query: str, **kwargs):
+        ...
+
+    def find(
+        self: 'T',
+        query: Union['DocumentArray', 'Document', 'ArrayType', Callable, Dict, str],
+        **kwargs,
+    ) -> 'DocumentArray':
+        from ...math.ndarray import to_numpy_array, get_array_type
+
+        if isinstance(query, (dict, str)):
+            return self.filter(query, **kwargs)
+        elif isinstance(query, (DocumentArray, Document)):
+            if isinstance(query, Document):
+                query = DocumentArray(query)
+                return self.search(query, **kwargs)[0].matches
+
+            return self.search(query, **kwargs)
+
+        try:
+            _, _ = get_array_type(query)
+            q_mat = to_numpy_array(query)
+            query = DocumentArray([Document(embedding=x) for x in q_mat])
+            if q_mat.ndim == 1:
+                query = DocumentArray(Document(embedding=q_mat))
+                return self.search(query, **kwargs)[0].matches
+            else:
+                query = DocumentArray([Document(embedding=x) for x in q_mat])
+                return self.search(query, **kwargs)
+        except Exception:
+            raise ValueError(
+                f'The find method of {self.__class__.__name__} does not support the type of query: {type(query)}'
+            )
+
+    def filter(self: 'T', query: Union[Dict, str], **kwargs) -> 'DocumentArray':
+        """Returns a new DocumentArray with filtering out docs that match with the given query function.
+
+        :return: DocumentArray containing all documents matching the given `query`
+        """
+        ...
+
+    def search(
+        self: 'T',
+        query: 'DocumentArray',
+        metric: Union[
+            str, Callable[['ArrayType', 'ArrayType'], 'np.ndarray']
+        ] = 'cosine',
+        limit: Optional[Union[int, float]] = 20,
+        normalization: Optional[Tuple[float, float]] = None,
+        metric_name: Optional[str] = None,
+        batch_size: Optional[int] = None,
+        exclude_self: bool = False,
+        only_id: bool = False,
+        use_scipy: bool = False,
+        device: str = 'cpu',
+        num_worker: Optional[int] = 1,
+        **kwargs,
+    ) -> 'DocumentArray':
+        """Returns approximate nearest neighbors given a batch of input queries.
+
+        :param query: the DocumentArray to search by their embeddings.
+        :param metric: the distance metric
+        :param limit: the maximum number of matches, when not given defaults to 20.
+        :param normalization: a tuple [a, b] to be used with min-max normalization,
+                                the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
+                                all values will be rescaled into range `[a, b]`.
+        :param metric_name: if provided, then match result will be marked with this string.
+        :param batch_size: if provided, then ``self.embeddings`` is loaded in batches, where each of them is at most ``batch_size``
+            elements. When `self.embeddings` is big, this can significantly speedup the computation.
+        :param exclude_self: if set, Documents in ``darray`` with same ``id`` as the left-hand values will not be
+                        considered as matches.
+        :param only_id: if set, then returning matches will only contain ``id``
+        :param use_scipy: if set, use ``scipy`` as the computation backend. Note, ``scipy`` does not support distance
+            on sparse matrix.
+        :param device: the computational device for ``.search()``, can be either `cpu` or `cuda`.
+        :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
+
+                .. note::
+                    This argument is only effective when ``batch_size`` is set.
+
+        :param kwargs: other kwargs.
+
+        :return: DocumentArray containing the closest documents to the query if it is a single query, otherwise a list of DocumentArrays containing
+           the closest Document objects for each of the queries in `query`.
+        """
+        if limit is not None:
+            if limit <= 0:
+                raise ValueError(f'`limit` must be larger than 0, receiving {limit}')
+            else:
+                limit = int(limit)
+
+        if batch_size is not None:
+            if batch_size <= 0:
+                raise ValueError(
+                    f'`batch_size` must be larger than 0, receiving {batch_size}'
+                )
+            else:
+                batch_size = int(batch_size)
+
+        if callable(metric):
+            cdist = metric
+        elif isinstance(metric, str):
+            if use_scipy:
+                from scipy.spatial.distance import cdist as cdist
+            else:
+                from ...math.distance import cdist as _cdist
+
+                cdist = lambda *x: _cdist(*x, device=device)
+        else:
+            raise TypeError(
+                f'metric must be either string or a 2-arity function, received: {metric!r}'
+            )
+
+        metric_name = metric_name or (metric.__name__ if callable(metric) else metric)
+        _limit = len(self) if limit is None else (limit + (1 if exclude_self else 0))
+
+        if batch_size:
+            dist, idx = self._search_online(
+                query, cdist, _limit, normalization, metric_name, batch_size, num_worker
+            )
+        else:
+            dist, idx = self._search(query, cdist, _limit, normalization, metric_name)
+
+        result = DocumentArray([Document(id=q.id) for q in query])
+        for _q, _ids, _dists in zip(result, idx, dist):
+            num_matches = 0
+            for _id, _dist in zip(_ids, _dists):
+                # Note, when match self with other, or both of them share the same Document
+                # we might have recursive matches .
+                # checkout https://github.com/jina-ai/jina/issues/3034
+                if only_id:
+                    d = Document(id=self[_id].id)
+                else:
+                    d = Document(self[int(_id)], copy=True)  # type: Document
+
+                if d.id in query:
+                    d = Document(
+                        d, copy=True
+                    )  # to prevent self-reference and override on matches
+                    d.pop('matches')
+                if not (d.id == _q.id and exclude_self):
+                    d.scores[metric_name] = NamedScore(value=_dist, ref_id=_q.id)
+                    _q.matches.append(d)
+                    num_matches += 1
+                    if num_matches >= (limit or _limit):
+                        break
+
+        return result
+
+    def _search(self, query: 'DocumentArray', cdist, limit, normalization, metric_name):
+        """
+        :param query: query: the DocumentArray to search by their embeddings.
+        :param cdist: the distance metric
+        :param limit: the maximum number of matches, when not given
+                      all Documents in `darray` are considered as matches
+        :param normalization: a tuple [a, b] to be used with min-max normalization,
+                                the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
+                                all values will be rescaled into range `[a, b]`.
+        :param metric_name: if provided, then match result will be marked with this string.
+        :return: distances and indices
+        """
+        dists = cdist(query.embeddings, self.embeddings, metric_name)
+        dist, idx = top_k(dists, min(limit, len(query)), descending=False)
+        if isinstance(normalization, (tuple, list)) and normalization is not None:
+            # normalization bound uses original distance not the top-k trimmed distance
+            min_d = np.min(dists, axis=-1, keepdims=True)
+            max_d = np.max(dists, axis=-1, keepdims=True)
+            dist = minmax_normalize(dist, normalization, (min_d, max_d))
+
+        return dist, idx
+
+    def _search_online(
+        self,
+        query,
+        cdist,
+        limit,
+        normalization,
+        metric_name,
+        batch_size,
+        num_worker,
+    ):
+        """
+
+        :param query: the DocumentArray to search by their embeddings.
+        :param cdist: the distance metric
+        :param limit: the maximum number of matches, when not given
+                      all Documents in `another` are considered as matches
+        :param normalization: a tuple [a, b] to be used with min-max normalization,
+                              the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
+                              all values will be rescaled into range `[a, b]`.
+        :param batch_size: length of the chunks loaded into memory from darray.
+        :param metric_name: if provided, then match result will be marked with this string.
+        :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
+        :return: distances and indices
+        """
+
+        n_q = len(query)
+
+        idx = 0
+        top_dists = np.inf * np.ones((n_q, limit))
+        top_inds = np.zeros((n_q, limit), dtype=int)
+
+        def _get_dist(da: 'DocumentArray'):
+            distances = cdist(query.embeddings, self.embeddings, metric_name)
+            dists, inds = top_k(distances, limit, descending=False)
+
+            if isinstance(normalization, (tuple, list)) and normalization is not None:
+                dists = minmax_normalize(dists, normalization)
+
+            return dists, inds, len(self)
+
+        if num_worker is None or num_worker > 1:
+            # notice that all most all computations (regardless the framework) are conducted in C
+            # hence there is no worry on Python GIL and the backend can be safely put to `thread` to
+            # save unnecessary data passing. This in fact gives a huge boost on the performance.
+            _gen = self.map_batch(
+                _get_dist,
+                batch_size=batch_size,
+                backend='thread',
+                num_worker=num_worker,
+            )
+        else:
+            _gen = (_get_dist(b) for b in self.batch(batch_size=batch_size))
+
+        for (dists, inds, _bs) in _gen:
+            inds += idx
+            idx += _bs
+            top_dists, top_inds = update_rows_x_mat_best(
+                top_dists, top_inds, dists, inds, limit
+            )
+
+        # sort final the final `top_dists` and `top_inds` per row
+        permutation = np.argsort(top_dists, axis=1)
+        dist = np.take_along_axis(top_dists, permutation, axis=1)
+        idx = np.take_along_axis(top_inds, permutation, axis=1)
+
+        return dist, idx

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -58,9 +58,6 @@ class FindMixin:
             else:
                 limit = int(limit)
 
-        # _limit = len(self) if limit is None else (limit + (1 if exclude_self else 0))
-        _limit = len(self) if limit is None else limit
-
         if isinstance(query, (DocumentArray, Document)):
             _limit = (
                 len(self) if limit is None else (limit + (1 if exclude_self else 0))
@@ -92,7 +89,7 @@ class FindMixin:
                     f'The find method of {self.__class__.__name__} does not support the type of query: {type(query)}'
                 )
 
-            # Ensure query embedding to have the correct shape via `.flatten()`
+            # Ensure query embedding to have the correct shape
             if n_dim != 2:
                 query = query.reshape((n_rows, -1))
 

--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -1,12 +1,8 @@
 from typing import Optional, Union, Callable, Tuple, TYPE_CHECKING
 
-import numpy as np
-
-from ...math.helper import top_k, minmax_normalize, update_rows_x_mat_best
-from ...score import NamedScore
-
 if TYPE_CHECKING:
-    from ...types import Document, ArrayType
+    import numpy as np
+    from ...types import ArrayType
     from ... import DocumentArray
 
 
@@ -80,5 +76,5 @@ class MatchMixin:
             num_worker=num_worker,
         )
 
-        for _r, _d in zip(result, self):
-            _d.matches = _r.matches
+        for r, d in zip(result, self):
+            d.matches = r

--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -62,8 +62,8 @@ class MatchMixin:
         :param kwargs: other kwargs.
         """
 
-        result = darray.search(
-            self,
+        match_docs = darray.find(
+            self.embeddings,
             metric=metric,
             limit=limit,
             normalization=normalization,
@@ -76,5 +76,8 @@ class MatchMixin:
             num_worker=num_worker,
         )
 
-        for r, d in zip(result, self):
-            d.matches = r
+        if isinstance(match_docs, DocumentArray):
+            match_docs = [match_docs]
+
+        for m, d in zip(match_docs, self):
+            d.matches = m

--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -62,10 +62,14 @@ class MatchMixin:
         :param kwargs: other kwargs.
         """
 
-        from ...math import ndarray
+        if not (self and darray):
+            return
+
+        for d in self:
+            d.matches.clear()
 
         match_docs = darray.find(
-            ndarray.to_numpy_array(self.embeddings),
+            self,
             metric=metric,
             limit=limit,
             normalization=normalization,
@@ -78,7 +82,7 @@ class MatchMixin:
             num_worker=num_worker,
         )
 
-        if isinstance(match_docs, DocumentArray):
+        if not isinstance(match_docs, list):
             match_docs = [match_docs]
 
         for m, d in zip(match_docs, self):

--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -62,8 +62,10 @@ class MatchMixin:
         :param kwargs: other kwargs.
         """
 
+        from ...math import ndarray
+
         match_docs = darray.find(
-            self.embeddings,
+            ndarray.to_numpy_array(self.embeddings),
             metric=metric,
             limit=limit,
             normalization=normalization,

--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -65,170 +65,20 @@ class MatchMixin:
 
         :param kwargs: other kwargs.
         """
-        if limit is not None:
-            if limit <= 0:
-                raise ValueError(f'`limit` must be larger than 0, receiving {limit}')
-            else:
-                limit = int(limit)
 
-        if batch_size is not None:
-            if batch_size <= 0:
-                raise ValueError(
-                    f'`batch_size` must be larger than 0, receiving {batch_size}'
-                )
-            else:
-                batch_size = int(batch_size)
+        result = darray.search(
+            self,
+            metric=metric,
+            limit=limit,
+            normalization=normalization,
+            metric_name=metric_name,
+            batch_size=batch_size,
+            exclude_self=exclude_self,
+            only_id=only_id,
+            use_scipy=use_scipy,
+            device=device,
+            num_worker=num_worker,
+        )
 
-        lhv = self
-        rhv = darray
-
-        if not (lhv and rhv):
-            return
-
-        if callable(metric):
-            cdist = metric
-        elif isinstance(metric, str):
-            if use_scipy:
-                from scipy.spatial.distance import cdist as cdist
-            else:
-                from ...math.distance import cdist as _cdist
-
-                cdist = lambda *x: _cdist(*x, device=device)
-        else:
-            raise TypeError(
-                f'metric must be either string or a 2-arity function, received: {metric!r}'
-            )
-
-        metric_name = metric_name or (metric.__name__ if callable(metric) else metric)
-        _limit = len(rhv) if limit is None else (limit + (1 if exclude_self else 0))
-
-        if batch_size:
-            dist, idx = lhv._match_online(
-                rhv, cdist, _limit, normalization, metric_name, batch_size, num_worker
-            )
-        else:
-            dist, idx = lhv._match(rhv, cdist, _limit, normalization, metric_name)
-
-        from ... import Document
-
-        for _q, _ids, _dists in zip(lhv, idx, dist):
-            _q.matches.clear()
-            num_matches = 0
-            for _id, _dist in zip(_ids, _dists):
-                # Note, when match self with other, or both of them share the same Document
-                # we might have recursive matches .
-                # checkout https://github.com/jina-ai/jina/issues/3034
-                if only_id:
-                    d = Document(id=rhv[_id].id)
-                else:
-                    d = Document(rhv[int(_id)], copy=True)  # type: Document
-
-                if d.id in lhv:
-                    d = Document(
-                        d, copy=True
-                    )  # to prevent self-reference and override on matches
-                    d.pop('matches')
-                if not (d.id == _q.id and exclude_self):
-                    d.scores[metric_name] = NamedScore(value=_dist, ref_id=_q.id)
-                    _q.matches.append(d)
-                    num_matches += 1
-                    if num_matches >= (limit or _limit):
-                        break
-
-    def _match(self, darray, cdist, limit, normalization, metric_name):
-        """
-        Computes the matches between self and `darray` loading `darray` into main memory.
-        :param darray: the other DocumentArray or  to match against
-        :param cdist: the distance metric
-        :param limit: the maximum number of matches, when not given
-                      all Documents in `darray` are considered as matches
-        :param normalization: a tuple [a, b] to be used with min-max normalization,
-                                the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
-                                all values will be rescaled into range `[a, b]`.
-        :param metric_name: if provided, then match result will be marked with this string.
-        :return: distances and indices
-        """
-
-        x_mat = self.embeddings
-        y_mat = darray.embeddings
-
-        dists = cdist(x_mat, y_mat, metric_name)
-        dist, idx = top_k(dists, min(limit, len(darray)), descending=False)
-        if isinstance(normalization, (tuple, list)) and normalization is not None:
-            # normalization bound uses original distance not the top-k trimmed distance
-            min_d = np.min(dists, axis=-1, keepdims=True)
-            max_d = np.max(dists, axis=-1, keepdims=True)
-            dist = minmax_normalize(dist, normalization, (min_d, max_d))
-
-        return dist, idx
-
-    def _match_online(
-        self,
-        darray,
-        cdist,
-        limit,
-        normalization,
-        metric_name,
-        batch_size,
-        num_worker,
-    ):
-        """
-        Computes the matches between self and `darray` loading `darray` into main memory in chunks of size `batch_size`.
-
-        :param darray: the other DocumentArray or  to match against
-        :param cdist: the distance metric
-        :param limit: the maximum number of matches, when not given
-                      all Documents in `another` are considered as matches
-        :param normalization: a tuple [a, b] to be used with min-max normalization,
-                              the min distance will be rescaled to `a`, the max distance will be rescaled to `b`
-                              all values will be rescaled into range `[a, b]`.
-        :param batch_size: length of the chunks loaded into memory from darray.
-        :param metric_name: if provided, then match result will be marked with this string.
-        :param num_worker: the number of parallel workers. If not given, then the number of CPUs in the system will be used.
-        :return: distances and indices
-        """
-
-        x_mat = self.embeddings
-        n_x = x_mat.shape[0]
-
-        idx = 0
-        top_dists = np.inf * np.ones((n_x, limit))
-        top_inds = np.zeros((n_x, limit), dtype=int)
-
-        def _get_dist(da: 'DocumentArray'):
-            y_batch = da.embeddings
-
-            distances = cdist(x_mat, y_batch, metric_name)
-            dists, inds = top_k(distances, limit, descending=False)
-
-            if isinstance(normalization, (tuple, list)) and normalization is not None:
-                dists = minmax_normalize(dists, normalization)
-
-            return dists, inds, y_batch.shape[0]
-
-        if num_worker is None or num_worker > 1:
-            # notice that all most all computations (regardless the framework) are conducted in C
-            # hence there is no worry on Python GIL and the backend can be safely put to `thread` to
-            # save unnecessary data passing. This in fact gives a huge boost on the performance.
-            _gen = darray.map_batch(
-                _get_dist,
-                batch_size=batch_size,
-                backend='thread',
-                num_worker=num_worker,
-            )
-        else:
-            _gen = (_get_dist(b) for b in darray.batch(batch_size=batch_size))
-
-        for (dists, inds, _bs) in _gen:
-            inds += idx
-            idx += _bs
-            top_dists, top_inds = update_rows_x_mat_best(
-                top_dists, top_inds, dists, inds, limit
-            )
-
-        # sort final the final `top_dists` and `top_inds` per row
-        permutation = np.argsort(top_dists, axis=1)
-        dist = np.take_along_axis(top_dists, permutation, axis=1)
-        idx = np.take_along_axis(top_inds, permutation, axis=1)
-
-        return dist, idx
+        for _r, _d in zip(result, self):
+            _d.matches = _r.matches

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -4,10 +4,11 @@ from typing import (
     TYPE_CHECKING,
     List,
 )
-from .... import Document, DocumentArray
+
 
 if TYPE_CHECKING:
     import numpy as np
+    from .... import DocumentArray
 
 
 class FindMixin:

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -1,50 +1,20 @@
 from typing import (
     Union,
+    Optional,
     TYPE_CHECKING,
     List,
 )
 
 if TYPE_CHECKING:
-    import numpy as np
     from .... import DocumentArray
 
 
 class FindMixin:
-    def _find_similar_vectors(self, q: 'np.ndarray', limit=10):
-
-        """
-        if q.ndim == 1:
-            input = DocumentArray(Document(embedding=q))
-        else:
-            input = DocumentArray(Document(embedding=q_k) for q_k in q)
-        docs = self._pqlite.search(input, limit=limit)
-        return DocumentArray(docs)
-        """
-
-        if q.ndim == 1:
-            q = q.reshape((1, -1))
-
-        _, list_of_docs = self._pqlite._search_documents(q, limit=limit)
-
-        if len(list_of_docs) == 1:
-            # this is a single DocumentArray
-            return list_of_docs[0]
-        else:
-            # this is a list of DocumentArrays
-            return list_of_docs
-
-    def find(
-        self, query: 'np.ndarray', limit: int = 10
-    ) -> Union['DocumentArray', List['DocumentArray']]:
-        """Returns approximate nearest neighbors given a batch of input queries.
-        :param query: input supported to be stored in Weaviate. This includes any from the list '[np.ndarray, tensorflow.Tensor, torch.Tensor, Sequence[float]]'
-        :param limit: number of retrieved items
-
-        :return: DocumentArray containing the closest documents to the query if it is a single query, otherwise a list of DocumentArrays containing
-           the closest Document objects for each of the queries in `query`.
-
-        Note: Weaviate returns `certainty` values. To get cosine similarities one needs to use `cosine_sim = 2*certainty - 1` as explained here:
-                  https://www.semi.technology/developers/weaviate/current/more-resources/faq.html#q-how-do-i-get-the-cosine-similarity-from-weaviates-certainty
-        """
-
-        return self._find_similar_vectors(query, limit=limit)
+    def search(
+        self,
+        query: 'DocumentArray',
+        limit: Optional[Union[int, float]] = 20,
+        **kwargs,
+    ) -> 'DocumentArray':
+        self._pqlite.search(query, limit=limit)
+        return query

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -14,7 +14,22 @@ class FindMixin:
         self,
         query: 'DocumentArray',
         limit: Optional[Union[int, float]] = 20,
+        only_id: bool = False,
         **kwargs,
-    ) -> 'DocumentArray':
-        self._pqlite.search(query, limit=limit)
-        return query
+    ) -> List['DocumentArray']:
+        """Returns approximate nearest neighbors given an input query.
+
+        :param query: the query documents to search.
+        :param limit: the number of results to get for each query document in search.
+        :param only_id: if set, then returning matches will only contain ``id``
+        :param kwargs: other kwargs.
+
+        :return: a list of DocumentArrays containing the closest Document objects for each of the queries in `query`.
+        """
+        if limit is not None:
+            if limit <= 0:
+                raise ValueError(f'`limit` must be larger than 0, receiving {limit}')
+            else:
+                limit = int(limit)
+        self._pqlite.search(query, limit=limit, include_metadata=not only_id, **kwargs)
+        return [q.matches for q in query]

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -46,7 +46,7 @@ class FindMixin:
             query = query.reshape(1, -1)
 
         _, match_docs = self._pqlite._search_documents(
-            query, limit=limit, include_metadata=not only_id, **kwargs
+            query, limit=limit, include_metadata=not only_id
         )
         if num_rows == 1:
             return match_docs[0]

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -4,10 +4,10 @@ from typing import (
     TYPE_CHECKING,
     List,
 )
+from .... import Document, DocumentArray
 
 if TYPE_CHECKING:
     import numpy as np
-    from .... import Document, DocumentArray
 
 
 class FindMixin:

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -36,18 +36,18 @@ class FindMixin:
             else:
                 limit = int(limit)
 
-        if isinstance(query, Document):
-            query = ndarray.to_numpy_array(query.embedding)
-        elif isinstance(query, DocumentArray):
-            query = ndarray.to_numpy_array(query.embeddings)
+        if isinstance(query, (DocumentArray, Document)):
+            if isinstance(query, Document):
+                query = DocumentArray(query)
+            query = query.embeddings
 
-        n_rows, _ = ndarray.get_array_rows(query)
-        if n_rows == 1:
+        num_rows, _ = ndarray.get_array_rows(query)
+        if num_rows == 1:
             query = query.reshape(1, -1)
 
         _, match_docs = self._pqlite._search_documents(
             query, limit=limit, include_metadata=not only_id, **kwargs
         )
-        if n_rows == 1:
+        if num_rows == 1:
             return match_docs[0]
         return match_docs

--- a/docarray/array/storage/pqlite/find.py
+++ b/docarray/array/storage/pqlite/find.py
@@ -36,9 +36,9 @@ class FindMixin:
             else:
                 limit = int(limit)
 
-        if isinstance(query, (DocumentArray, Document)):
-            if isinstance(query, Document):
-                query = DocumentArray(query)
+        if isinstance(query, Document):
+            query = query.embedding
+        elif isinstance(query, DocumentArray):
             query = query.embeddings
 
         num_rows, _ = ndarray.get_array_rows(query)

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -66,12 +66,9 @@ class FindMixin:
 
         return DocumentArray(docs)
 
-    def find(
-        self,
-        query: Union['Document', 'DocumentArray', 'WeaviateArrayType'],
-        limit: int = 10,
-        **kwargs
-    ) -> Union['DocumentArray', List['DocumentArray']]:
+    def _find(
+        self, query: 'WeaviateArrayType', limit: int = 10, **kwargs
+    ) -> List['DocumentArray']:
         """Returns approximate nearest neighbors given a batch of input queries.
         :param query: input supported to be stored in Weaviate. This includes any from the list '[np.ndarray, tensorflow.Tensor, torch.Tensor, Sequence[float]]'
         :param limit: number of retrieved items
@@ -83,15 +80,10 @@ class FindMixin:
                   https://www.semi.technology/developers/weaviate/current/more-resources/faq.html#q-how-do-i-get-the-cosine-similarity-from-weaviates-certainty
         """
 
-        if isinstance(query, (DocumentArray, Document)):
-            if isinstance(query, Document):
-                query = DocumentArray(query)
-            query = query.embeddings
-
         num_rows, _ = ndarray.get_array_rows(query)
 
         if num_rows == 1:
-            return self._find_similar_vectors(query, limit=limit)
+            return [self._find_similar_vectors(query, limit=limit)]
         else:
             closest_docs = []
             for q in query:

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -52,7 +52,10 @@ class FindMixin:
         return DocumentArray(docs)
 
     def find(
-        self, query: 'WeaviateArrayType', limit: int = 10
+        self,
+        query: Union['Document', 'DocumentArray', 'WeaviateArrayType'],
+        limit: int = 10,
+        **kwargs
     ) -> Union['DocumentArray', List['DocumentArray']]:
         """Returns approximate nearest neighbors given a batch of input queries.
         :param query: input supported to be stored in Weaviate. This includes any from the list '[np.ndarray, tensorflow.Tensor, torch.Tensor, Sequence[float]]'
@@ -64,6 +67,11 @@ class FindMixin:
         Note: Weaviate returns `certainty` values. To get cosine similarities one needs to use `cosine_sim = 2*certainty - 1` as explained here:
                   https://www.semi.technology/developers/weaviate/current/more-resources/faq.html#q-how-do-i-get-the-cosine-similarity-from-weaviates-certainty
         """
+
+        if isinstance(query, (DocumentArray, Document)):
+            if isinstance(query, Document):
+                query = DocumentArray(query)
+            query = query.embeddings
 
         num_rows, _ = ndarray.get_array_rows(query)
 

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -37,13 +37,17 @@ class FindMixin:
             .do()
         )
         docs = []
-
         # The serialized document is stored in results['data']['Get'][self._class_name]
         for result in results.get('data', {}).get('Get', {}).get(self._class_name, []):
             doc = Document.from_base64(result['_serialized'], **self._serialize_config)
             certainty = result['_additional']['certainty']
+
             doc.scores['weaviate_certainty'] = NamedScore(value=certainty)
-            doc.scores['cosine_similarity'] = NamedScore(value=2 * certainty - 1)
+            if certainty is None:
+                doc.scores['cosine_similarity'] = NamedScore(value=None)
+            else:
+                doc.scores['cosine_similarity'] = NamedScore(value=2 * certainty - 1)
+
             doc.tags = {
                 'wid': result['_additional']['id'],
             }

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -51,7 +51,7 @@ class FindMixin:
 
         return DocumentArray(docs)
 
-    def find(self, query: 'DocumentArray', limit: int = 10) -> List['DocumentArray']:
+    def search(self, query: 'DocumentArray', limit: int = 10) -> List['DocumentArray']:
         """Returns approximate nearest neighbors given a batch of input queries.
         :param query: the DocumentArray to search by their embeddings.
         :param limit: number of retrieved items

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -5,9 +5,7 @@ from typing import (
     Sequence,
     List,
 )
-
 import numpy as np
-
 from .... import Document, DocumentArray
 from ....math import ndarray
 from ....score import NamedScore
@@ -15,7 +13,6 @@ from ....score import NamedScore
 if TYPE_CHECKING:
     import tensorflow
     import torch
-    import numpy as np
 
     WeaviateArrayType = TypeVar(
         'WeaviateArrayType',

--- a/docarray/array/storage/weaviate/find.py
+++ b/docarray/array/storage/weaviate/find.py
@@ -51,27 +51,21 @@ class FindMixin:
 
         return DocumentArray(docs)
 
-    def find(
-        self, query: 'WeaviateArrayType', limit: int = 10
-    ) -> Union['DocumentArray', List['DocumentArray']]:
+    def find(self, query: 'DocumentArray', limit: int = 10) -> List['DocumentArray']:
         """Returns approximate nearest neighbors given a batch of input queries.
-        :param query: input supported to be stored in Weaviate. This includes any from the list '[np.ndarray, tensorflow.Tensor, torch.Tensor, Sequence[float]]'
+        :param query: the DocumentArray to search by their embeddings.
         :param limit: number of retrieved items
 
-        :return: DocumentArray containing the closest documents to the query if it is a single query, otherwise a list of DocumentArrays containing
-           the closest Document objects for each of the queries in `query`.
+        :return: a list of DocumentArrays containing the closest Document objects for each of the queries in `query`.
 
         Note: Weaviate returns `certainty` values. To get cosine similarities one needs to use `cosine_sim = 2*certainty - 1` as explained here:
                   https://www.semi.technology/developers/weaviate/current/more-resources/faq.html#q-how-do-i-get-the-cosine-similarity-from-weaviates-certainty
         """
 
-        num_rows, _ = ndarray.get_array_rows(query)
-
-        if num_rows == 1:
-            return self._find_similar_vectors(query, limit=limit)
-        else:
-            closest_docs = []
-            for q in query:
-                da = self._find_similar_vectors(q, limit=limit)
-                closest_docs.append(da)
-            return closest_docs
+        result = []
+        for q in query:
+            matches = self._find_similar_vectors(
+                ndarray.to_numpy_array(q.embedding), limit=limit
+            )
+            result.append(matches)
+        return result

--- a/docarray/math/distance/__init__.py
+++ b/docarray/math/distance/__init__.py
@@ -40,7 +40,7 @@ def cdist(
     if x_type != y_type:
         raise ValueError(
             f'The type of your left-hand side is {x_type}, whereas your right-hand side is {y_type}. '
-            f'`.match()` requires left must be the same type as right.'
+            f'`.cdist()` requires left must be the same type as right.'
         )
 
     framework, is_sparse = get_array_type(x_mat)

--- a/tests/unit/array/mixins/test_find.py
+++ b/tests/unit/array/mixins/test_find.py
@@ -7,7 +7,8 @@ from docarray.math import ndarray
 
 
 @pytest.mark.parametrize(
-    'storage, config', [('weaviate', WeaviateConfig(32)), ('pqlite', {'n_dim': 32})]
+    'storage, config',
+    [('memory', None), ('weaviate', WeaviateConfig(32)), ('pqlite', {'n_dim': 32})],
 )
 @pytest.mark.parametrize('limit', [1, 5, 10])
 @pytest.mark.parametrize(
@@ -42,7 +43,7 @@ def test_find(storage, config, limit, query, start_weaviate):
                 t['cosine_similarity'].value for t in result[:, 'scores']
             ]
             assert sorted(cosine_similarities, reverse=True) == cosine_similarities
-        elif storage == 'pqlite':
+        elif storage in ['memory', 'pqlite']:
             cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
             assert sorted(cosine_distances, reverse=False) == cosine_distances
     else:
@@ -52,7 +53,7 @@ def test_find(storage, config, limit, query, start_weaviate):
                     t['cosine_similarity'].value for t in da[:, 'scores']
                 ]
                 assert sorted(cosine_similarities, reverse=True) == cosine_similarities
-        elif storage == 'pqlite':
+        elif storage in ['memory', 'pqlite']:
             for da in result:
                 cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
                 assert sorted(cosine_distances, reverse=False) == cosine_distances

--- a/tests/unit/array/mixins/test_find.py
+++ b/tests/unit/array/mixins/test_find.py
@@ -24,16 +24,14 @@ def test_find(storage, config, limit, query, start_weaviate):
 
     da.extend([Document(embedding=v) for v in embeddings])
 
-    da_result = da.find(query, limit=limit)
+    result = da.find(query, limit=limit)
     n_rows_query, _ = ndarray.get_array_rows(query)
-
-    print(f'\n\n\ntype(da_result)={type(da_result)}')
 
     # check for each row on the query a DocumentArray is returned
     if n_rows_query == 1:
-        assert len(da_result) == limit
+        assert len(result) == limit
     else:
-        assert len(da_result) == n_rows_query
+        assert len(result) == n_rows_query
 
     # check returned objects are sorted according to the storage backend metric
     # weaviate uses cosine similarity by default
@@ -41,20 +39,20 @@ def test_find(storage, config, limit, query, start_weaviate):
     if n_rows_query == 1:
         if storage == 'weaviate':
             cosine_similarities = [
-                t['cosine_similarity'].value for t in da_result[:, 'scores']
+                t['cosine_similarity'].value for t in result[:, 'scores']
             ]
             assert sorted(cosine_similarities, reverse=True) == cosine_similarities
-        elif storage == 'weaviate':
+        elif storage == 'pqlite':
             cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
             assert sorted(cosine_distances, reverse=False) == cosine_distances
     else:
         if storage == 'weaviate':
-            for da in da_result:
+            for da in result:
                 cosine_similarities = [
                     t['cosine_similarity'].value for t in da[:, 'scores']
                 ]
                 assert sorted(cosine_similarities, reverse=True) == cosine_similarities
         elif storage == 'pqlite':
-            for da in da_result:
+            for da in result:
                 cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
                 assert sorted(cosine_distances, reverse=False) == cosine_distances

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -70,7 +70,8 @@ def doc_lists_to_doc_arrays(doc_lists, *args, **kwargs):
 
 
 @pytest.mark.parametrize(
-    'storage, config', [('weaviate', WeaviateConfig(3)), ('pqlite', {'n_dim': 3})]
+    'storage, config',
+    [('weaviate', WeaviateConfig(3)), ('pqlite', {'n_dim': 3})],
 )
 @pytest.mark.parametrize('limit', [1, 2, 3])
 def test_match(storage, config, doc_lists, limit, start_weaviate):
@@ -84,6 +85,12 @@ def test_match(storage, config, doc_lists, limit, start_weaviate):
     D1.match(da, limit=limit)
     for m in D1[:, 'matches']:
         assert len(m) == limit
+
+    expected_sorted_values = [
+        D1[0].matches[i].scores['cosine'].value for i in range(limit)
+    ]
+
+    assert expected_sorted_values == sorted(expected_sorted_values)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -10,6 +10,7 @@ from scipy.sparse import csr_matrix, bsr_matrix, coo_matrix, csc_matrix
 from scipy.spatial.distance import cdist as scipy_cdist
 
 from docarray import Document, DocumentArray
+from docarray.array.storage.weaviate import WeaviateConfig
 
 
 @pytest.fixture()
@@ -66,6 +67,23 @@ def doc_lists_to_doc_arrays(doc_lists, *args, **kwargs):
     D2 = DocumentArray()
     D2.extend(doc_list2)
     return D1, D2
+
+
+@pytest.mark.parametrize(
+    'storage, config', [('weaviate', WeaviateConfig(3)), ('pqlite', {'n_dim': 3})]
+)
+@pytest.mark.parametrize('limit', [1, 5, 10])
+def test_match(storage, config, doc_lists, limit, start_weaviate):
+    D1, D2 = doc_lists_to_doc_arrays(doc_lists)
+
+    if config:
+        da = DocumentArray(D2, storage=storage, config=config)
+    else:
+        da = DocumentArray(D2, storage=storage)
+
+    D1.match(da, limit=limit)
+    for m in D1[:, 'matches']:
+        assert len(m) == limit
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -72,7 +72,7 @@ def doc_lists_to_doc_arrays(doc_lists, *args, **kwargs):
 @pytest.mark.parametrize(
     'storage, config', [('weaviate', WeaviateConfig(3)), ('pqlite', {'n_dim': 3})]
 )
-@pytest.mark.parametrize('limit', [1, 5, 10])
+@pytest.mark.parametrize('limit', [1, 2, 3])
 def test_match(storage, config, doc_lists, limit, start_weaviate):
     D1, D2 = doc_lists_to_doc_arrays(doc_lists)
 

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -82,6 +82,7 @@ def test_matching_retrieves_correct_number(
     D1, D2 = doc_lists_to_doc_arrays(
         doc_lists,
     )
+
     D1.match(
         D2, metric='sqeuclidean', limit=limit, batch_size=batch_size, only_id=only_id
     )


### PR DESCRIPTION
**WANING**: To enable the `match` function to work,   the implementation of `find()` needs to allow the query input as `DocumentArray` (since we need to support **exclude_self** parameter).

```
from docarray import Document, DocumentArray
import numpy as np
N = 100
D = 8

da = DocumentArray([Document(id=f'{i}', embedding=x) for i, x in zip(range(N), np.random.rand(N, D))])

q = Document(embedding=np.random.random(D))

### query is `Document`
result = da.find(q, limit=10)
q.match(da, limit=10)

### query is `DocumentArray`
qa = DocumentArray(q)
result = da.find(qa, limit=10)
qa.match(da, limit=10)

qa = DocumentArray([q] * 2, limit=10)
result = da.find(qa, limit=10)
qa.match(da)

### query is `ndarray`
qx = np.random.random(D)
result = da.find(qx, limit=10)

qx = np.random.rand(5, D)
result = da.find(qx, limit=10)
```

## DocumentArrayPqlite

```
pq_da = DocumentArray(da, storage='pqlite', config={'n_dim': D})
result = pq_da.find(qa, limit=10)
qa.match(pq_da)
print(qa.summary())

```