### PR TITLE
fix: use utf-8 encoding for csv reading

### DIFF
--- a/docarray/array/mixins/io/common.py
+++ b/docarray/array/mixins/io/common.py
@@ -19,7 +19,7 @@ class CommonIOMixin:
         :param file_format: `json` or `binary` or `csv`. JSON and CSV files are human-readable,
             but binary format gives much smaller size and faster save/load speed. Note that, CSV file has very limited
             compatability, complex DocumentArray with nested structure can not be restored from a CSV file.
-        :param encoding: encoding used to save data into the file (it only applies to `JSON` and `CSV` format).
+        :param encoding: encoding used to save data into a file (it only applies to `JSON` and `CSV` format).
             By default, ``utf-8`` is used.
         """
         if file_format == 'json':
@@ -45,7 +45,7 @@ class CommonIOMixin:
         :param file_format: `json` or `binary` or `csv`. JSON and CSV files are human-readable,
             but binary format gives much smaller size and faster save/load speed. CSV file has very limited compatability,
             complex DocumentArray with nested structure can not be restored from a CSV file.
-        :param encoding: encoding used to load data from the file (it only applies to `JSON` and `CSV` format).
+        :param encoding: encoding used to load data from a file (it only applies to `JSON` and `CSV` format).
             By default, ``utf-8`` is used.
 
         :return: the loaded DocumentArray object

--- a/docarray/array/mixins/io/common.py
+++ b/docarray/array/mixins/io/common.py
@@ -8,7 +8,10 @@ class CommonIOMixin:
     """The common IO helper function for arrays. """
 
     def save(
-        self, file: Union[str, TextIO, BinaryIO], file_format: str = 'binary'
+        self,
+        file: Union[str, TextIO, BinaryIO],
+        file_format: str = 'binary',
+        encoding: str = 'utf-8',
     ) -> None:
         """Save array elements into a JSON, a binary file or a CSV file.
 
@@ -16,13 +19,15 @@ class CommonIOMixin:
         :param file_format: `json` or `binary` or `csv`. JSON and CSV files are human-readable,
             but binary format gives much smaller size and faster save/load speed. Note that, CSV file has very limited
             compatability, complex DocumentArray with nested structure can not be restored from a CSV file.
+        :param encoding: encoding used to save data into the file (it only applies to `JSON` and `CSV` format).
+            By default, ``utf-8`` is used.
         """
         if file_format == 'json':
-            self.save_json(file)
+            self.save_json(file, encoding=encoding)
         elif file_format == 'binary':
             self.save_binary(file)
         elif file_format == 'csv':
-            self.save_csv(file)
+            self.save_csv(file, encoding=encoding)
         else:
             raise ValueError('`format` must be one of [`json`, `binary`, `csv`]')
 
@@ -31,6 +36,7 @@ class CommonIOMixin:
         cls: Type['T'],
         file: Union[str, TextIO, BinaryIO],
         file_format: str = 'binary',
+        encoding: str = 'utf-8',
         **kwargs
     ) -> 'T':
         """Load array elements from a JSON or a binary file, or a CSV file.
@@ -39,14 +45,16 @@ class CommonIOMixin:
         :param file_format: `json` or `binary` or `csv`. JSON and CSV files are human-readable,
             but binary format gives much smaller size and faster save/load speed. CSV file has very limited compatability,
             complex DocumentArray with nested structure can not be restored from a CSV file.
+        :param encoding: encoding used to load data from the file (it only applies to `JSON` and `CSV` format).
+            By default, ``utf-8`` is used.
 
         :return: the loaded DocumentArray object
         """
         if file_format == 'json':
-            return cls.load_json(file, **kwargs)
+            return cls.load_json(file, encoding=encoding, **kwargs)
         elif file_format == 'binary':
             return cls.load_binary(file)
         elif file_format == 'csv':
-            return cls.load_csv(file)
+            return cls.load_csv(file, encoding=encoding)
         else:
             raise ValueError('`format` must be one of [`json`, `binary`, `csv`]')

--- a/docarray/array/mixins/io/csv.py
+++ b/docarray/array/mixins/io/csv.py
@@ -14,18 +14,21 @@ class CsvIOMixin:
     can be applied to DA & DAM
     """
 
-    def save_embeddings_csv(self, file: Union[str, TextIO], **kwargs) -> None:
+    def save_embeddings_csv(
+        self, file: Union[str, TextIO], encoding: str = 'utf-8', **kwargs
+    ) -> None:
         """Save embeddings to a CSV file
 
         This function utilizes :meth:`numpy.savetxt` internal.
 
         :param file: File or filename to which the data is saved.
+        :param encoding: encoding used to dump the data. By default, ``utf-8`` is used.
         :param kwargs: extra kwargs will be passed to :meth:`numpy.savetxt`.
         """
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
         else:
-            file_ctx = open(file, 'w')
+            file_ctx = open(file, 'w', encoding='utf-8')
         with file_ctx:
             np.savetxt(file_ctx, self.embeddings, **kwargs)
 
@@ -36,6 +39,7 @@ class CsvIOMixin:
         exclude_fields: Optional[Sequence[str]] = None,
         dialect: Union[str, 'csv.Dialect'] = 'excel',
         with_header: bool = True,
+        encoding: str = 'utf-8',
     ) -> None:
         """Save array elements into a CSV file.
 
@@ -46,11 +50,12 @@ class CsvIOMixin:
         :param dialect: define a set of parameters specific to a particular CSV dialect. could be a string that represents
             predefined dialects in your system, or could be a :class:`csv.Dialect` class that groups specific formatting
             parameters together.
+        :param encoding: encoding used to dump the CSV file. By default, ``utf-8`` is used.
         """
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
         else:
-            file_ctx = open(file, 'w')
+            file_ctx = open(file, 'w', encoding=encoding)
 
         with file_ctx as fp:
             if flatten_tags and self[0].tags:
@@ -88,15 +93,17 @@ class CsvIOMixin:
         cls: Type['T'],
         file: Union[str, TextIO],
         field_resolver: Optional[Dict[str, str]] = None,
+        encoding: str = 'utf-8',
     ) -> 'T':
         """Load array elements from a binary file.
 
         :param file: File or filename to which the data is saved.
         :param field_resolver: a map from field names defined in JSON, dict to the field
             names defined in Document.
+        :param encoding: encoding used to read the CSV file. By default, ``utf-8`` is used.
         :return: a DocumentArray object
         """
 
         from ....document.generators import from_csv
 
-        return cls(from_csv(file, field_resolver=field_resolver))
+        return cls(from_csv(file, field_resolver=field_resolver, encoding=encoding))

--- a/docarray/array/mixins/io/csv.py
+++ b/docarray/array/mixins/io/csv.py
@@ -28,7 +28,7 @@ class CsvIOMixin:
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
         else:
-            file_ctx = open(file, 'w', encoding='utf-8')
+            file_ctx = open(file, 'w', encoding=encoding)
         with file_ctx:
             np.savetxt(file_ctx, self.embeddings, **kwargs)
 

--- a/docarray/array/mixins/io/csv.py
+++ b/docarray/array/mixins/io/csv.py
@@ -22,7 +22,7 @@ class CsvIOMixin:
         This function utilizes :meth:`numpy.savetxt` internal.
 
         :param file: File or filename to which the data is saved.
-        :param encoding: encoding used to dump the data. By default, ``utf-8`` is used.
+        :param encoding: encoding used to save the data into a file. By default, ``utf-8`` is used.
         :param kwargs: extra kwargs will be passed to :meth:`numpy.savetxt`.
         """
         if hasattr(file, 'write'):
@@ -50,7 +50,7 @@ class CsvIOMixin:
         :param dialect: define a set of parameters specific to a particular CSV dialect. could be a string that represents
             predefined dialects in your system, or could be a :class:`csv.Dialect` class that groups specific formatting
             parameters together.
-        :param encoding: encoding used to dump the CSV file. By default, ``utf-8`` is used.
+        :param encoding: encoding used to save the data into a CSV file. By default, ``utf-8`` is used.
         """
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
@@ -100,7 +100,7 @@ class CsvIOMixin:
         :param file: File or filename to which the data is saved.
         :param field_resolver: a map from field names defined in JSON, dict to the field
             names defined in Document.
-        :param encoding: encoding used to read the CSV file. By default, ``utf-8`` is used.
+        :param encoding: encoding used to read a CSV file. By default, ``utf-8`` is used.
         :return: a DocumentArray object
         """
 

--- a/docarray/array/mixins/io/json.py
+++ b/docarray/array/mixins/io/json.py
@@ -11,7 +11,11 @@ class JsonIOMixin:
     """Save/load a array into a JSON file."""
 
     def save_json(
-        self, file: Union[str, TextIO], protocol: str = 'jsonschema', **kwargs
+        self,
+        file: Union[str, TextIO],
+        protocol: str = 'jsonschema',
+        encoding: str = 'utf-8',
+        **kwargs
     ) -> None:
         """Save array elements into a JSON file.
 
@@ -19,11 +23,12 @@ class JsonIOMixin:
 
         :param file: File or filename to which the data is saved.
         :param protocol: `jsonschema` or `protobuf`
+        :param encoding: encoding used to dump data into the JSON file. By default, ``utf-8`` is used.
         """
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
         else:
-            file_ctx = open(file, 'w')
+            file_ctx = open(file, 'w', encoding=encoding)
 
         with file_ctx as fp:
             for d in self:
@@ -32,12 +37,18 @@ class JsonIOMixin:
 
     @classmethod
     def load_json(
-        cls: Type['T'], file: Union[str, TextIO], protocol: str = 'jsonschema', **kwargs
+        cls: Type['T'],
+        file: Union[str, TextIO],
+        protocol: str = 'jsonschema',
+        encoding: str = 'utf-8',
+        **kwargs
     ) -> 'T':
         """Load array elements from a JSON file.
 
         :param file: File or filename or a JSON string to which the data is saved.
         :param protocol: `jsonschema` or `protobuf`
+        :param encoding: encoding used to load data from the JSON file. By default, ``utf-8`` is used.
+
         :return: a DocumentArrayLike object
         """
 
@@ -47,7 +58,7 @@ class JsonIOMixin:
         if hasattr(file, 'read'):
             file_ctx = nullcontext(file)
         elif os.path.exists(file):
-            file_ctx = open(file)
+            file_ctx = open(file, 'r', encoding=encoding)
         else:
             file_ctx = nullcontext(json.loads(file))
             constructor = Document.from_dict
@@ -57,9 +68,13 @@ class JsonIOMixin:
 
     @classmethod
     def from_json(
-        cls: Type['T'], file: Union[str, TextIO], protocol: str = 'jsonschema', **kwargs
+        cls: Type['T'],
+        file: Union[str, TextIO],
+        protocol: str = 'jsonschema',
+        encoding: str = 'utf-8',
+        **kwargs
     ) -> 'T':
-        return cls.load_json(file, protocol=protocol, **kwargs)
+        return cls.load_json(file, protocol=protocol, encoding=encoding, **kwargs)
 
     @classmethod
     def from_list(

--- a/docarray/array/mixins/io/json.py
+++ b/docarray/array/mixins/io/json.py
@@ -23,7 +23,7 @@ class JsonIOMixin:
 
         :param file: File or filename to which the data is saved.
         :param protocol: `jsonschema` or `protobuf`
-        :param encoding: encoding used to dump data into the JSON file. By default, ``utf-8`` is used.
+        :param encoding: encoding used to save data into a JSON file. By default, ``utf-8`` is used.
         """
         if hasattr(file, 'write'):
             file_ctx = nullcontext(file)
@@ -47,7 +47,7 @@ class JsonIOMixin:
 
         :param file: File or filename or a JSON string to which the data is saved.
         :param protocol: `jsonschema` or `protobuf`
-        :param encoding: encoding used to load data from the JSON file. By default, ``utf-8`` is used.
+        :param encoding: encoding used to load data from a JSON file. By default, ``utf-8`` is used.
 
         :return: a DocumentArrayLike object
         """

--- a/docarray/document/generators.py
+++ b/docarray/document/generators.py
@@ -133,6 +133,7 @@ def from_csv(
         parameters together. If you don't know the dialect and the default one does not work for you,
         you can try set it to ``auto``.
     :param encoding: encoding used to read the CSV file. By default, ``utf-8`` is used.
+
     :yield: documents
 
     """

--- a/docarray/document/generators.py
+++ b/docarray/document/generators.py
@@ -117,6 +117,7 @@ def from_csv(
     size: Optional[int] = None,
     sampling_rate: Optional[float] = None,
     dialect: Union[str, 'csv.Dialect'] = 'excel',
+    encoding: str = 'utf-8',
     *args,
     **kwargs,
 ) -> Generator['Document', None, None]:
@@ -131,6 +132,7 @@ def from_csv(
         predefined dialects in your system, or could be a :class:`csv.Dialect` class that groups specific formatting
         parameters together. If you don't know the dialect and the default one does not work for you,
         you can try set it to ``auto``.
+    :param encoding: encoding used to read the CSV file. By default, ``utf-8`` is used.
     :yield: documents
 
     """
@@ -139,7 +141,7 @@ def from_csv(
     if hasattr(file, 'read'):
         file_ctx = nullcontext(file)
     else:
-        file_ctx = open(file, 'r', encoding='utf-8')
+        file_ctx = open(file, 'r', encoding=encoding)
 
     with file_ctx as fp:
         # when set to auto, then sniff

--- a/docarray/document/generators.py
+++ b/docarray/document/generators.py
@@ -139,7 +139,7 @@ def from_csv(
     if hasattr(file, 'read'):
         file_ctx = nullcontext(file)
     else:
-        file_ctx = open(file, 'r')
+        file_ctx = open(file, 'r', encoding='utf-8')
 
     with file_ctx as fp:
         # when set to auto, then sniff

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -19,6 +19,7 @@ def docs():
 
 @pytest.mark.slow
 @pytest.mark.parametrize('method', ['json', 'binary'])
+@pytest.mark.parametrize('encoding', ['utf-8', 'cp1252'])
 @pytest.mark.parametrize(
     'da_cls,config',
     [
@@ -28,12 +29,16 @@ def docs():
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=10)),
     ],
 )
-def test_document_save_load(docs, method, tmp_path, da_cls, config, start_weaviate):
+def test_document_save_load(
+    docs, method, encoding, tmp_path, da_cls, config, start_weaviate
+):
     tmp_file = os.path.join(tmp_path, 'test')
     da = da_cls(docs, config=config())
-    da.save(tmp_file, file_format=method)
+    da.save(tmp_file, file_format=method, encoding=encoding)
 
-    da_r = type(da).load(tmp_file, file_format=method, config=config())
+    da_r = type(da).load(
+        tmp_file, file_format=method, encoding=encoding, config=config()
+    )
 
     assert type(da) is type(da_r)
     assert len(da) == len(da_r)


### PR DESCRIPTION
I am not 100% sure about this PR, so please think about it **carefully**.

In Jina the chatbot example is currently broken in Windows, because the csv dataset cant be read correctly. This file [here]('https://static.jina.ai/chatbot/dataset.csv') .

Reading this file with `DocumentArray.from_csv` will result in this error:

`
File "c:\users\tobias\pycharmprojects\hello_jina\venv\lib\site-packages\docarray\document\generators.py", line 302, in _sample
    for i in iterable:
  File "C:\Users\tobias\AppData\Local\Programs\Python\Python38\lib\csv.py", line 111, in next
    row = next(self.reader)
  File "C:\Users\tobias\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3204: character maps to <undefined>
`

The problem is that the csv file is opened without providing any encoding. This means [Python will use some OS dependant encoding](https://docs.python.org/3/library/functions.html#open). Linux correctly assumes 'utf-8', but Windows tries `cp1252` and fails.

Thus this PR hard codes the encoding to `utf-8`, which should work in most cases I think. I am not sure about some undesired side effects in some Operating systems though.