### PR TITLE
refactor(array): change primary view to dict and 2nd view to list

### DIFF
--- a/docarray/array/mixins/delitem.py
+++ b/docarray/array/mixins/delitem.py
@@ -26,7 +26,7 @@ class DelItemMixin:
                     'Delete elements along traversal paths is not implemented'
                 )
             else:
-                self._del_doc_by_id(index)
+                self._del_doc(index)
         elif isinstance(index, slice):
             self._del_docs_by_slice(index)
         elif index is Ellipsis:

--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -77,7 +77,7 @@ class SetItemMixin:
             # set by ID
             # allows da['id_123'] = Document()
             else:
-                self._set_doc_by_id(index, value)
+                self._set_doc(index, value)
         # set by slice
         # allows da[1:3] = [d1, d2]
         elif isinstance(index, slice):
@@ -211,7 +211,7 @@ class SetItemMixin:
                     elif _a == 'embedding':
                         _docs.embeddings = _v
                     for _d in _docs:
-                        self._set_doc_by_id(_d.id, _d)
+                        self._set_doc(_d.id, _d)
                 else:
                     if not isinstance(_v, (list, tuple)):
                         for _d in _docs:

--- a/docarray/array/storage/base/backend.py
+++ b/docarray/array/storage/base/backend.py
@@ -17,7 +17,7 @@ class BaseBackendMixin(ABC):
         *args,
         **kwargs
     ):
-        self._offset2ids = Offset2ID()
+        self._offset2ids = self._load_offset2ids()
 
     def _get_storage_infos(self) -> Dict:
         return {'Class': self.__class__.__name__}

--- a/docarray/array/storage/base/backend.py
+++ b/docarray/array/storage/base/backend.py
@@ -17,12 +17,7 @@ class BaseBackendMixin(ABC):
         *args,
         **kwargs
     ):
-        from ... import DocumentArray
-
-        if isinstance(_docs, DocumentArray):
-            self._offset2ids = _docs._offset2ids
-        else:
-            self._offset2ids = Offset2ID()
+        self._offset2ids = Offset2ID()
 
     def _get_storage_infos(self) -> Dict:
         return {'Class': self.__class__.__name__}

--- a/docarray/array/storage/base/backend.py
+++ b/docarray/array/storage/base/backend.py
@@ -17,7 +17,7 @@ class BaseBackendMixin(ABC):
         *args,
         **kwargs
     ):
-        self._offset2ids = self._load_offset2ids()
+        self._load_offset2ids()
 
     def _get_storage_infos(self) -> Dict:
         return {'Class': self.__class__.__name__}

--- a/docarray/array/storage/base/backend.py
+++ b/docarray/array/storage/base/backend.py
@@ -1,11 +1,28 @@
-from abc import ABC, abstractmethod
-from typing import Dict
+from abc import ABC
+from typing import Dict, Optional, TYPE_CHECKING
+
+from docarray.array.storage.base.helper import Offset2ID
+
+if TYPE_CHECKING:
+    from ....types import (
+        DocumentArraySourceType,
+    )
 
 
 class BaseBackendMixin(ABC):
-    @abstractmethod
-    def _init_storage(self, *args, **kwargs):
-        ...
+    def _init_storage(
+        self,
+        _docs: Optional['DocumentArraySourceType'] = None,
+        copy: bool = False,
+        *args,
+        **kwargs
+    ):
+        from ... import DocumentArray
+
+        if isinstance(_docs, DocumentArray):
+            self._offset2ids = _docs._offset2ids
+        else:
+            self._offset2ids = Offset2ID()
 
     def _get_storage_infos(self) -> Dict:
         return {'Class': self.__class__.__name__}

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -199,6 +199,11 @@ class BaseGetSetDelMixin(ABC):
         :param attr: the attribute of document to update
         :param value: the value doc's attr will be updated to
         """
+        if attr == 'id' and value is None:
+            raise ValueError(
+                'pop id from Document stored in a DocumentArray is not allowed'
+            )
+
         d = self._get_doc_by_id(_id)
         if hasattr(d, attr):
             setattr(d, attr, value)

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -63,10 +63,10 @@ class BaseGetSetDelMixin(ABC):
 
     def _del_doc_by_offset(self, offset: int):
         self._del_doc_by_id(self._offset2ids.get_id(offset))
-        del self._offset2ids[offset]
+        self._offset2ids.delete_by_offset(offset)
 
     def _del_doc(self, _id: str):
-        del self._offset2ids[self._offset2ids.index(_id)]
+        self._offset2ids.delete_by_id(_id)
         self._del_doc_by_id(_id)
 
     @abstractmethod
@@ -103,7 +103,7 @@ class BaseGetSetDelMixin(ABC):
     # Setitem API
 
     def _set_doc_by_offset(self, offset: int, value: 'Document'):
-        self._set_doc_by_id(self._offset2ids.get_id(offset), value)
+        self._set_doc(self._offset2ids.get_id(offset), value)
 
     def _set_doc(self, _id: str, value: 'Document'):
         if _id != value.id:

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -100,7 +100,7 @@ class BaseGetSetDelMixin(ABC):
         self._clear_storage()
         self._offset2ids = Offset2ID()
 
-    @abstractmethod
+    # TODO: make this abstract
     def _clear_storage(self):
         ...
 

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -147,6 +147,7 @@ class BaseGetSetDelMixin(ABC):
             self._set_doc_by_id(_id, doc)
 
     def _set_docs(self, ids, docs: Iterable['Document']):
+        docs = list(docs)
         self._set_docs_by_ids(ids, docs)
         mismatch_ids = {_id: doc.id for _id, doc in zip(ids, docs) if _id != doc.id}
         self._offset2ids.update_ids(mismatch_ids)

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -18,6 +18,7 @@ class BaseGetSetDelMixin(ABC):
             - :meth:`._get_doc_by_id`
             - :meth:`._set_doc_by_id`
             - :meth:`._del_doc_by_id`
+            - :meth:`._clear_storage`
 
         Other methods implemented a generic-but-slow version that leverage the methods above.
         Please override those methods in the subclass whenever a more efficient implementation is available.
@@ -96,9 +97,12 @@ class BaseGetSetDelMixin(ABC):
         """This function is derived and may not have the most efficient implementation.
 
         Override this function if there is a more efficient logic"""
-        for _id in self._offset2ids:
-            self._del_doc_by_id(_id)
+        self._clear_storage()
         self._offset2ids = Offset2ID()
+
+    @abstractmethod
+    def _clear_storage(self):
+        ...
 
     # Setitem API
 

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -92,7 +92,6 @@ class BaseGetSetDelMixin(ABC):
         Override this function if there is a more efficient logic
         :param mask: the boolean mask used for indexing
         """
-        # TODO: rebuild offset2ids once
         ids = list(itertools.compress(self._offset2ids, (not _i for _i in mask)))
         self._del_docs(ids)
 

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -165,7 +165,7 @@ class BaseGetSetDelMixin(ABC):
             )
 
         ids = self._offset2ids.get_id(_slice)
-        self._set_docs(ids)
+        self._set_docs(ids, value)
 
     def _set_doc_value_pairs(
         self, docs: Iterable['Document'], values: Sequence['Document']

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -100,7 +100,7 @@ class BaseGetSetDelMixin(ABC):
         self._clear_storage()
         self._offset2ids = Offset2ID()
 
-    # TODO: make this abstract
+    @abstractmethod
     def _clear_storage(self):
         ...
 

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -235,7 +235,7 @@ class BaseGetSetDelMixin(ABC):
         """
         if attr == 'id' and value is None:
             raise ValueError(
-                'pop id from Document stored in a DocumentArray is not allowed'
+                'setting the ID of a Document stored in a DocumentArray to None is not allowed'
             )
 
         d = self._get_doc_by_id(_id)

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -256,3 +256,14 @@ class BaseGetSetDelMixin(ABC):
             if d.id in _all_ids:
                 da[d.id].copy_from(d)
                 return _d
+
+    @abstractmethod
+    def _load_offset2ids(self):
+        ...
+
+    @abstractmethod
+    def _save_offset2ids(self):
+        ...
+
+    def __del__(self):
+        self._save_offset2ids()

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -37,7 +37,7 @@ class Offset2ID:
         self.offset2id = list(filter(lambda _id: _id not in ids, self.offset2id))
 
     def update_ids(self, _ids_map: Dict[str, str]):
-        for i in len(self.offset2id):
+        for i in range(len(self.offset2id)):
             if self.offset2id[i] in _ids_map:
                 self.offset2id[i] = _ids_map[self.offset2id[i]]
 

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -40,3 +40,6 @@ class Offset2ID:
 
     def __eq__(self, other):
         return self.offset2id == other.offset2id
+
+    def __len__(self):
+        return len(self.offset2id)

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Tuple, Dict
+from typing import Iterator, Dict
 
 
 class Offset2ID:

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -11,6 +11,9 @@ class Offset2ID:
     def append(self, data):
         self.offset2id.append(data)
 
+    def extend(self, data):
+        self.offset2id.extend(data)
+
     def update(self, position, data_id):
         self.offset2id[position] = data_id
 

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, List, Tuple, Dict
 
 
 class Offset2ID:
@@ -31,6 +31,15 @@ class Offset2ID:
 
     def clear(self):
         self.offset2id.clear()
+
+    def delete_by_ids(self, ids):
+        ids = set(ids)
+        self.offset2id = list(filter(lambda _id: _id not in ids, self.offset2id))
+
+    def update_ids(self, _ids_map: Dict[str, str]):
+        for i in len(self.offset2id):
+            if self.offset2id[i] in _ids_map:
+                self.offset2id[i] = _ids_map[self.offset2id[i]]
 
     def save(self):
         pass

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -26,6 +26,9 @@ class Offset2ID:
     def insert(self, position, data_id):
         self.offset2id.insert(position, data_id)
 
+    def clear(self):
+        self.offset2id.clear()
+
     def save(self):
         pass
 

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -37,3 +37,6 @@ class Offset2ID:
 
     def __iter__(self) -> Iterator['str']:
         yield from self.offset2id
+
+    def __eq__(self, other):
+        return self.offset2id == other.offset2id

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -1,0 +1,36 @@
+from typing import Iterator
+
+
+class Offset2ID:
+    def __init__(self):
+        self.offset2id = []
+
+    def get_id(self, idx):
+        return self.offset2id[idx]
+
+    def append(self, data):
+        self.offset2id.append(data)
+
+    def update(self, position, data_id):
+        self.offset2id[position] = data_id
+
+    def delete_by_id(self, _id):
+        del self.offset2id[self.offset2id.index(_id)]
+
+    def index(self, _id):
+        return self.offset2id.index(_id)
+
+    def delete_by_offset(self, position):
+        del self.offset2id[position]
+
+    def insert(self, position, data_id):
+        self.offset2id.insert(position, data_id)
+
+    def save(self):
+        pass
+
+    def load(self):
+        pass
+
+    def __iter__(self) -> Iterator['str']:
+        yield from self.offset2id

--- a/docarray/array/storage/base/seqlike.py
+++ b/docarray/array/storage/base/seqlike.py
@@ -1,5 +1,5 @@
-from typing import Iterator, Union, Iterable, MutableSequence
-from abc import ABC, abstractmethod
+from typing import Iterator, Iterable, MutableSequence
+from abc import abstractmethod
 
 from .... import Document
 

--- a/docarray/array/storage/base/seqlike.py
+++ b/docarray/array/storage/base/seqlike.py
@@ -1,0 +1,55 @@
+from typing import Iterator, Union, Iterable, MutableSequence
+from abc import ABC, abstractmethod
+
+from .... import Document
+
+
+class BaseSequenceLikeMixin(MutableSequence[Document]):
+    """Implement sequence-like methods"""
+
+    def insert(self, index: int, value: 'Document'):
+        """Insert `doc` at `index`.
+
+        :param index: Position of the insertion.
+        :param value: The doc needs to be inserted.
+        """
+        self._set_doc_by_id(value.id, value)
+        self._offset2ids.insert(index, value.id)
+
+    def append(self, value: 'Document'):
+        """Append `doc` to the end of the array.
+
+        :param value: The doc needs to be appended.
+        """
+        self._set_doc_by_id(value.id, value)
+        self._offset2ids.append(value.id)
+
+    @abstractmethod
+    def __eq__(self, other):
+        ...
+
+    def __len__(self):
+        return len(self._offset2ids)
+
+    def __iter__(self) -> Iterator['Document']:
+        for _id in self._offset2ids:
+            yield self._get_doc_by_id(_id)
+
+    @abstractmethod
+    def __contains__(self, other):
+        ...
+
+    def clear(self):
+        """Clear the data of :class:`DocumentArray`"""
+        self._del_all_docs()
+
+    def __bool__(self):
+        """To simulate ```l = []; if l: ...```
+
+        :return: returns true if the length of the array is larger than 0
+        """
+        return len(self) > 0
+
+    def extend(self, values: Iterable['Document']) -> None:
+        for value in values:
+            self.append(value)

--- a/docarray/array/storage/memory/backend.py
+++ b/docarray/array/storage/memory/backend.py
@@ -31,21 +31,20 @@ class BackendMixin(BaseBackendMixin):
     ):
         super()._init_storage(_docs, copy=copy, *args, **kwargs)
 
-        from ...memory import DocumentArrayInMemory
+        from ... import DocumentArray
 
         self._data = {}
         if _docs is None:
             return
         elif isinstance(
             _docs,
-            (DocumentArrayInMemory, Sequence, Generator, Iterator, itertools.chain),
+            (DocumentArray, Sequence, Generator, Iterator, itertools.chain),
         ):
             if copy:
-                self._data = {d.id: Document(d, copy=True) for d in _docs}
-            elif isinstance(_docs, DocumentArrayInMemory):
-                self._data = _docs._data
+                for doc in _docs:
+                    self.append(Document(doc, copy=True))
             else:
-                self._data = {doc.id: doc for doc in _docs}
+                self.extend(_docs)
         else:
             if isinstance(_docs, Document):
                 if copy:

--- a/docarray/array/storage/memory/backend.py
+++ b/docarray/array/storage/memory/backend.py
@@ -19,44 +19,9 @@ if TYPE_CHECKING:
     )
 
 
-def needs_id2offset_rebuild(func) -> Callable:
-    # self._id2offset needs to be rebuilt after every insert or delete
-    # this flag allows to do it lazily and cache the result
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        self._needs_id2offset_rebuild = True
-        return func(self, *args, **kwargs)
-
-    return wrapper
-
-
 class BackendMixin(BaseBackendMixin):
     """Provide necessary functions to enable this storage backend."""
 
-    @property
-    def _id2offset(self) -> Dict[str, int]:
-        """Return the `_id_to_index` map
-
-        :return: a Python dict.
-        """
-        if self._needs_id2offset_rebuild:
-            self._rebuild_id2offset()
-
-        return self._id_to_index
-
-    def _rebuild_id2offset(self) -> None:
-        """Update the id_to_index map by enumerating all Documents in self._data.
-
-        Very costy! Only use this function when self._data is dramtically changed.
-        """
-
-        self._id_to_index = {
-            d.id: i for i, d in enumerate(self._data)
-        }  # type: Dict[str, int]
-
-        self._needs_id2offset_rebuild = False
-
-    @needs_id2offset_rebuild
     def _init_storage(
         self,
         _docs: Optional['DocumentArraySourceType'] = None,
@@ -64,26 +29,23 @@ class BackendMixin(BaseBackendMixin):
         *args,
         **kwargs
     ):
-        from ... import DocumentArray
+        super()._init_storage(_docs, copy=copy, *args, **kwargs)
+
         from ...memory import DocumentArrayInMemory
 
-        self._data = []
-        self._id_to_index = {}
+        self._data = {}
         if _docs is None:
             return
         elif isinstance(
-            _docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
+            _docs,
+            (DocumentArrayInMemory, Sequence, Generator, Iterator, itertools.chain),
         ):
             if copy:
-                self._data = [Document(d, copy=True) for d in _docs]
-            elif isinstance(_docs, DocumentArray):
+                self._data = {d.id: Document(d, copy=True) for d in _docs}
+            elif isinstance(_docs, DocumentArrayInMemory):
                 self._data = _docs._data
             else:
-                self._data = list(_docs)
-
-            if isinstance(_docs, DocumentArrayInMemory):
-                self._id_to_index = _docs._id2offset
-                self._needs_id2offset_rebuild = _docs._needs_id2offset_rebuild
+                self._data = {doc.id: doc for doc in _docs}
         else:
             if isinstance(_docs, Document):
                 if copy:

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -11,10 +11,6 @@ from .... import Document
 class GetSetDelMixin(BaseGetSetDelMixin):
     """Implement required and derived functions that power `getitem`, `setitem`, `delitem`"""
 
-    def _del_all_docs(self):
-        self._data.clear()
-        self._offset2ids.clear()
-
     def _del_doc_by_id(self, _id: str):
         del self._data[_id]
 

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -21,9 +21,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _set_doc_by_id(self, _id: str, value: 'Document'):
         if _id != value.id:
             del self._data[_id]
-            self._data[value.id] = value
-        else:
-            self._data[_id] = value
+        self._data[value.id] = value
 
     def _set_doc_value_pairs(
         self, docs: Iterable['Document'], values: Sequence['Document']
@@ -38,3 +36,6 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _get_docs_by_ids(self, ids: Sequence[str]) -> Iterable['Document']:
         return (self._data[_id] for _id in ids)
+
+    def _clear_storage(self):
+        self._data.clear()

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import (
     Sequence,
     Iterable,
@@ -6,44 +5,25 @@ from typing import (
 )
 
 from ..base.getsetdel import BaseGetSetDelMixin
-from ..memory.backend import needs_id2offset_rebuild
 from .... import Document
 
 
 class GetSetDelMixin(BaseGetSetDelMixin):
     """Implement required and derived functions that power `getitem`, `setitem`, `delitem`"""
 
-    @needs_id2offset_rebuild
-    def _del_docs_by_mask(self, mask: Sequence[bool]):
-        self._data = list(itertools.compress(self._data, (not _i for _i in mask)))
-
     def _del_all_docs(self):
         self._data.clear()
-        self._id2offset.clear()
-
-    @needs_id2offset_rebuild
-    def _del_docs_by_slice(self, _slice: slice):
-        del self._data[_slice]
+        self._offset2ids.clear()
 
     def _del_doc_by_id(self, _id: str):
-        self._del_doc_by_offset(self._id2offset[_id])
-
-    @needs_id2offset_rebuild
-    def _del_doc_by_offset(self, offset: int):
-        del self._data[offset]
-
-    def _set_doc_by_offset(self, offset: int, value: 'Document'):
-        self._data[offset] = value
-        self._id2offset[value.id] = offset
+        del self._data[_id]
 
     def _set_doc_by_id(self, _id: str, value: 'Document'):
-        old_idx = self._id2offset.pop(_id)
-        self._data[old_idx] = value
-        self._id2offset[value.id] = old_idx
-
-    @needs_id2offset_rebuild
-    def _set_docs_by_slice(self, _slice: slice, value: Sequence['Document']):
-        self._data[_slice] = value
+        if _id != value.id:
+            del self._data[_id]
+            self._data[value.id] = value
+        else:
+            self._data[_id] = value
 
     def _set_doc_value_pairs(
         self, docs: Iterable['Document'], values: Sequence['Document']
@@ -53,28 +33,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         for _d, _v in zip(docs, values):
             _d._data = _v._data
 
-    def _set_doc_attr_by_offset(self, offset: int, attr: str, value: Any):
-        setattr(self._data[offset], attr, value)
-
-    def _set_doc_attr_by_id(self, _id: str, attr: str, value: Any):
-        if attr == 'id':
-            old_idx = self._id2offset.pop(_id)
-            setattr(self._data[old_idx], attr, value)
-            self._id2offset[value] = old_idx
-        else:
-            setattr(self._data[self._id2offset[_id]], attr, value)
-
-    def _get_doc_by_offset(self, offset: int) -> 'Document':
-        return self._data[offset]
-
     def _get_doc_by_id(self, _id: str) -> 'Document':
-        return self._data[self._id2offset[_id]]
-
-    def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
-        return self._data[_slice]
-
-    def _get_docs_by_offsets(self, offsets: Sequence[int]) -> Iterable['Document']:
-        return (self._data[t] for t in offsets)
+        return self._data[_id]
 
     def _get_docs_by_ids(self, ids: Sequence[str]) -> Iterable['Document']:
-        return (self._data[self._id2offset[t]] for t in ids)
+        return (self._data[_id] for _id in ids)

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -5,6 +5,7 @@ from typing import (
 )
 
 from ..base.getsetdel import BaseGetSetDelMixin
+from ..base.helper import Offset2ID
 from .... import Document
 
 
@@ -35,3 +36,9 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _clear_storage(self):
         self._data.clear()
+
+    def _load_offset2ids(self):
+        self._offset2ids = Offset2ID()
+
+    def _save_offset2ids(self):
+        ...

--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -12,13 +12,11 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             type(self) is type(other)
             and type(self._data) is type(other._data)
             and self._data == other._data
+            and self._offset2ids == other._offset2ids
         )
 
     def __len__(self):
         return len(self._data)
-
-    def __iter__(self) -> Iterator['Document']:
-        yield from self._data.values()
 
     def __contains__(self, x: Union[str, 'Document']):
         if isinstance(x, str):

--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -1,29 +1,11 @@
-from typing import Iterator, Union, Iterable, MutableSequence
+from typing import Iterator, Union, Iterable
 
-from ..memory.backend import needs_id2offset_rebuild
+from ..base.seqlike import BaseSequenceLikeMixin
 from .... import Document
 
 
-class SequenceLikeMixin(MutableSequence[Document]):
+class SequenceLikeMixin(BaseSequenceLikeMixin):
     """Implement sequence-like methods"""
-
-    @needs_id2offset_rebuild
-    def insert(self, index: int, value: 'Document'):
-        """Insert `doc` at `index`.
-
-        :param index: Position of the insertion.
-        :param value: The doc needs to be inserted.
-        """
-        self._data.insert(index, value)
-
-    def append(self, value: 'Document'):
-        """Append `doc` to the end of the array.
-
-        :param value: The doc needs to be appended.
-        """
-        self._data.append(value)
-        if not self._needs_id2offset_rebuild:
-            self._id_to_index[value.id] = len(self) - 1
 
     def __eq__(self, other):
         return (
@@ -36,7 +18,7 @@ class SequenceLikeMixin(MutableSequence[Document]):
         return len(self._data)
 
     def __iter__(self) -> Iterator['Document']:
-        yield from self._data
+        yield from self._data.values()
 
     def __contains__(self, x: Union[str, 'Document']):
         if isinstance(x, str):
@@ -46,17 +28,6 @@ class SequenceLikeMixin(MutableSequence[Document]):
         else:
             return False
 
-    def clear(self):
-        """Clear the data of :class:`DocumentArray`"""
-        self._del_all_docs()
-
-    def __bool__(self):
-        """To simulate ```l = []; if l: ...```
-
-        :return: returns true if the length of the array is larger than 0
-        """
-        return len(self) > 0
-
     def __repr__(self):
         return f'<DocumentArray (length={len(self)}) at {id(self)}>'
 
@@ -64,9 +35,3 @@ class SequenceLikeMixin(MutableSequence[Document]):
         v = type(self)(self)
         v.extend(other)
         return v
-
-    def extend(self, values: Iterable['Document']) -> None:
-        values = list(values)  # consume the iterator only once
-        last_idx = len(self._id2offset)
-        self._data.extend(values)
-        self._id_to_index.update({d.id: i + last_idx for i, d in enumerate(values)})

--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -22,9 +22,9 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
     def __contains__(self, x: Union[str, 'Document']):
         if isinstance(x, str):
-            return x in self._id2offset
+            return x in self._data
         elif isinstance(x, Document):
-            return x.id in self._id2offset
+            return x.id in self._data
         else:
             return False
 

--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -15,9 +15,6 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             and self._offset2ids == other._offset2ids
         )
 
-    def __len__(self):
-        return len(self._data)
-
     def __contains__(self, x: Union[str, 'Document']):
         if isinstance(x, str):
             return x in self._data

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -37,7 +37,6 @@ class BackendMixin(BaseBackendMixin):
         config: Optional[Union[PqliteConfig, Dict]] = None,
         **kwargs,
     ):
-        super()._init_storage()
         if not config:
             raise ValueError('Config object must be specified')
         elif isinstance(config, dict):
@@ -58,6 +57,8 @@ class BackendMixin(BaseBackendMixin):
         self._pqlite = PQLite(n_dim, **config)
         from ... import DocumentArray
         from .... import Document
+
+        super()._init_storage()
 
         if _docs is None:
             return

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -74,7 +74,6 @@ class BackendMixin(BaseBackendMixin):
     def __getstate__(self):
         state = dict(self.__dict__)
         del state['_pqlite']
-        del state['_offset2ids']
         return state
 
     def __setstate__(self, state):

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -54,7 +54,7 @@ class BackendMixin(BaseBackendMixin):
         config = asdict(config)
         n_dim = config.pop('n_dim')
 
-        self._pqlite = PQLite(n_dim, **config)
+        self._pqlite = PQLite(n_dim, lock=False, **config)
         from ... import DocumentArray
         from .... import Document
 
@@ -87,7 +87,7 @@ class BackendMixin(BaseBackendMixin):
 
         from pqlite import PQLite
 
-        self._pqlite = PQLite(n_dim, **config)
+        self._pqlite = PQLite(n_dim, lock=False, **config)
 
     def _get_storage_infos(self) -> Dict:
         storage_infos = super()._get_storage_infos()

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -75,6 +75,7 @@ class BackendMixin(BaseBackendMixin):
     def __getstate__(self):
         state = dict(self.__dict__)
         del state['_pqlite']
+        del state['_offsetmapping']
         return state
 
     def __setstate__(self, state):

--- a/docarray/array/storage/pqlite/backend.py
+++ b/docarray/array/storage/pqlite/backend.py
@@ -37,6 +37,7 @@ class BackendMixin(BaseBackendMixin):
         config: Optional[Union[PqliteConfig, Dict]] = None,
         **kwargs,
     ):
+        super()._init_storage()
         if not config:
             raise ValueError('Config object must be specified')
         elif isinstance(config, dict):
@@ -51,16 +52,10 @@ class BackendMixin(BaseBackendMixin):
 
         self._config = config
 
-        from .helper import OffsetMapping
-
         config = asdict(config)
         n_dim = config.pop('n_dim')
 
         self._pqlite = PQLite(n_dim, **config)
-        self._offset2ids = OffsetMapping(
-            data_path=config['data_path'],
-            in_memory=False,
-        )
         from ... import DocumentArray
         from .... import Document
 
@@ -90,13 +85,8 @@ class BackendMixin(BaseBackendMixin):
         n_dim = config.pop('n_dim')
 
         from pqlite import PQLite
-        from .helper import OffsetMapping
 
         self._pqlite = PQLite(n_dim, **config)
-        self._offset2ids = OffsetMapping(
-            data_path=config['data_path'],
-            in_memory=False,
-        )
 
     def _get_storage_infos(self) -> Dict:
         storage_infos = super()._get_storage_infos()

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -31,6 +31,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _set_docs_by_ids(self, ids, docs: Iterable['Document']):
         docs = DocumentArrayInMemory(docs)
+        for doc in docs:
+            self._to_numpy_embedding(doc)
         self._pqlite.update(docs)
 
     def _del_docs_by_ids(self, ids):

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from ..base.getsetdel import BaseGetSetDelMixin
 from ...memory import DocumentArrayInMemory
 from .... import Document
@@ -24,3 +26,9 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _clear_storage(self):
         self._pqlite.clear()
+
+    def _set_docs_by_ids(self, ids, docs: Iterable['Document']):
+        self._pqlite.update(ids)
+
+    def _del_docs_by_ids(self, ids):
+        self._pqlite.delete(ids)

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -30,7 +30,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._pqlite.clear()
 
     def _set_docs_by_ids(self, ids, docs: Iterable['Document']):
-        self._pqlite.update(ids)
+        docs = DocumentArrayInMemory(docs)
+        self._pqlite.update(docs)
 
     def _del_docs_by_ids(self, ids):
         self._pqlite.delete(ids)

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -32,3 +32,9 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _del_docs_by_ids(self, ids):
         self._pqlite.delete(ids)
+
+    def _load_offset2ids(self):
+        ...
+
+    def _save_offset2ids(self):
+        ...

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -15,75 +15,16 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     # essential methods start
 
-    def _get_doc_by_offset(self, offset: int) -> 'Document':
-        offset = len(self) + offset if offset < 0 else offset
-        doc_id = self._offset2ids.get_id_by_offset(offset)
-        doc = self._pqlite.get_doc_by_id(doc_id) if doc_id else None
-        if doc is None:
-            raise IndexError('index out of range')
-        return doc
-
     def _get_doc_by_id(self, _id: str) -> 'Document':
         doc = self._pqlite.get_doc_by_id(_id)
         if doc is None:
             raise KeyError(f'Can not find Document with id=`{_id}`')
         return doc
 
-    def _get_docs_by_offsets(self, offsets: Sequence[int]) -> Iterable['Document']:
-        ids = self._offset2ids.get_ids_by_offsets(offsets)
-        return self._get_docs_by_ids(ids)
-
-    def _get_docs_by_ids(self, ids: str) -> Iterable['Document']:
-        for _id in ids:
-            yield self._get_doc_by_id(_id)
-
-    def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
-        return self._get_docs_by_offsets(range(len(self))[_slice])
-
-    def _get_docs_by_mask(self, mask: Sequence[bool]):
-        offsets = [i for i, m in enumerate(mask) if m is True]
-        return self._get_docs_by_offsets(offsets)
-
-    def _set_doc_by_offset(self, offset: int, value: 'Document'):
-        offset = len(self) + offset if offset < 0 else offset
-        self._offset2ids.set_at_offset(offset, value.id)
+    def _set_doc_by_id(self, _id: str, value: 'Document'):
         self._to_numpy_embedding(value)
         docs = DocumentArrayInMemory([value])
         self._pqlite.update(docs)
 
-    def _set_doc_by_id(self, _id: str, value: 'Document'):
-        offset = self._offset2ids.get_offset_by_id(_id)
-        self._set_doc_by_offset(offset, value)
-
-    def _set_doc_value_pairs(
-        self, docs: Iterable['Document'], values: Iterable['Document']
-    ):
-        for _d, _v in zip(docs, values):
-            self._set_doc_by_id(_d.id, _v)
-
     def _del_doc_by_id(self, _id: str):
-        offset = self._offset2ids.get_offset_by_id(_id)
-        self._offset2ids.del_at_offset(offset, commit=True)
         self._pqlite.delete([_id])
-
-    def _del_doc_by_offset(self, offset: int):
-        offset = len(self) + offset if offset < 0 else offset
-        _id = self._offset2ids.get_id_by_offset(offset)
-        self._offset2ids.del_at_offset(offset)
-        self._pqlite.delete([_id])
-
-    def _del_doc_by_offsets(self, offsets: Sequence[int]):
-        ids = []
-        for offset in offsets:
-            ids.append(self._offset2ids.get_id_by_offset(offset))
-
-        self._offset2ids.del_at_offsets(offsets)
-        self._pqlite.delete(ids)
-
-    def _del_docs_by_slice(self, _slice: slice):
-        offsets = range(len(self))[_slice]
-        self._del_doc_by_offsets(offsets)
-
-    def _del_docs_by_mask(self, mask: Sequence[bool]):
-        offsets = [i for i, m in enumerate(mask) if m is True]
-        self._del_doc_by_offsets(offsets)

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -38,7 +38,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _load_offset2ids(self):
         self._offset2ids = Offset2ID()
         self._offsetmapping = OffsetMapping(
-            data_path=self._config['data_path'], in_memory=False
+            data_path=self._config.data_path, in_memory=False
         )
         self._offsetmapping.create_table()
         self._offset2ids.offset2id = self._offsetmapping.get_all_ids()

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -28,3 +28,6 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _del_doc_by_id(self, _id: str):
         self._pqlite.delete([_id])
+
+    def _clear_storage(self):
+        self._pqlite.clear()

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -1,10 +1,3 @@
-from typing import (
-    Sequence,
-    Iterable,
-)
-
-import numpy as np
-
 from ..base.getsetdel import BaseGetSetDelMixin
 from ...memory import DocumentArrayInMemory
 from .... import Document

--- a/docarray/array/storage/pqlite/getsetdel.py
+++ b/docarray/array/storage/pqlite/getsetdel.py
@@ -1,6 +1,8 @@
 from typing import Iterable
 
+from .helper import OffsetMapping
 from ..base.getsetdel import BaseGetSetDelMixin
+from ..base.helper import Offset2ID
 from ...memory import DocumentArrayInMemory
 from .... import Document
 
@@ -34,7 +36,16 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._pqlite.delete(ids)
 
     def _load_offset2ids(self):
-        ...
+        self._offset2ids = Offset2ID()
+        self._offsetmapping = OffsetMapping(
+            data_path=self._config['data_path'], in_memory=False
+        )
+        self._offsetmapping.create_table()
+        self._offset2ids.offset2id = self._offsetmapping.get_all_ids()
 
     def _save_offset2ids(self):
-        ...
+        self._offsetmapping.drop()
+        self._offsetmapping.create_table()
+        self._offsetmapping._insert(
+            [(i, doc_id) for i, doc_id in enumerate(self._offset2ids.offset2id)]
+        )

--- a/docarray/array/storage/pqlite/helper.py
+++ b/docarray/array/storage/pqlite/helper.py
@@ -25,6 +25,10 @@ class OffsetMapping(Table):
 
         self.execute(sql, commit=True)
 
+    def drop(self):
+        sql = f'''DROP TABLE IF NOT EXISTS {self.name}'''
+        self.execute(sql, commit=True)
+
     def clear(self):
         super().clear()
         self._size = None
@@ -67,6 +71,11 @@ class OffsetMapping(Table):
         sql = f'SELECT offset FROM {self.name} WHERE doc_id=? LIMIT 1;'
         result = self._conn.execute(sql, (doc_id,)).fetchone()
         return result[0] if result else None
+
+    def get_all_ids(self):
+        sql = f'SELECT offset FROM {self.name}'
+        result = self._conn.execute(sql).fetchall()
+        return [r[0] for r in result] if result else None
 
     def del_at_offset(self, offset: int, commit: bool = True):
         offset = len(self) + offset if offset < 0 else offset

--- a/docarray/array/storage/pqlite/helper.py
+++ b/docarray/array/storage/pqlite/helper.py
@@ -21,12 +21,12 @@ class OffsetMapping(Table):
     def create_table(self):
         sql = f'''CREATE TABLE IF NOT EXISTS {self.name}
                             (offset INTEGER NOT NULL PRIMARY KEY,
-                             doc_id INTEGER TEXT NOT NULL)'''
+                             doc_id TEXT NOT NULL)'''
 
         self.execute(sql, commit=True)
 
     def drop(self):
-        sql = f'''DROP TABLE IF NOT EXISTS {self.name}'''
+        sql = f'''DROP TABLE IF EXISTS {self.name}'''
         self.execute(sql, commit=True)
 
     def clear(self):
@@ -73,9 +73,9 @@ class OffsetMapping(Table):
         return result[0] if result else None
 
     def get_all_ids(self):
-        sql = f'SELECT offset FROM {self.name}'
+        sql = f'SELECT doc_id FROM {self.name} ORDER BY offset'
         result = self._conn.execute(sql).fetchall()
-        return [r[0] for r in result] if result else None
+        return [r[0] for r in result] if result else []
 
     def del_at_offset(self, offset: int, commit: bool = True):
         offset = len(self) + offset if offset < 0 else offset

--- a/docarray/array/storage/pqlite/seqlike.py
+++ b/docarray/array/storage/pqlite/seqlike.py
@@ -8,22 +8,6 @@ from ...memory import DocumentArrayInMemory
 class SequenceLikeMixin(MutableSequence['Document']):
     """Implement sequence-like methods"""
 
-    def insert(self, index: int, value: 'Document'):
-        """Insert `doc` at `index`.
-
-        :param index: Position of the insertion.
-        :param value: The doc needs to be inserted.
-        """
-        self._to_numpy_embedding(value)
-
-        self._pqlite.index(DocumentArrayInMemory([value]))
-        self._offset2ids.insert_at_offset(index, value.id)
-
-    def append(self, value: 'Document') -> None:
-        self._to_numpy_embedding(value)
-        self._pqlite.index(DocumentArrayInMemory([value]))
-        self._offset2ids.extend_doc_ids([value.id])
-
     def extend(self, values: Iterable['Document']) -> None:
         docs = DocumentArrayInMemory(values)
         if len(docs) == 0:
@@ -33,11 +17,9 @@ class SequenceLikeMixin(MutableSequence['Document']):
             self._to_numpy_embedding(doc)
 
         self._pqlite.index(docs)
-        self._offset2ids.extend_doc_ids([doc.id for doc in docs])
+        self._offset2ids.extend([doc.id for doc in docs])
 
-    def clear(self):
-        """Clear the data of :class:`DocumentArray`"""
-        self._offset2ids.clear()
+    def _clear_storage(self):
         self._pqlite.clear()
 
     def __del__(self) -> None:
@@ -52,21 +34,6 @@ class SequenceLikeMixin(MutableSequence['Document']):
             and type(self._config) is type(other._config)
             and self._config == other._config
         )
-
-    def __len__(self):
-        return self._offset2ids.size
-
-    def __iter__(self) -> Iterator['Document']:
-        for i in range(len(self)):
-            yield self[i]
-
-    def __contains__(self, x: Union[str, 'Document']):
-        if isinstance(x, str):
-            return self._offset2ids.get_offset_by_id(x) is not None
-        elif isinstance(x, Document):
-            return self._offset2ids.get_offset_by_id(x.id) is not None
-        else:
-            return False
 
     def __bool__(self):
         """To simulate ```l = []; if l: ...```

--- a/docarray/array/storage/pqlite/seqlike.py
+++ b/docarray/array/storage/pqlite/seqlike.py
@@ -20,9 +20,6 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
         self._pqlite.index(docs)
         self._offset2ids.extend([doc.id for doc in docs])
 
-    def _clear_storage(self):
-        self._pqlite.clear()
-
     def __del__(self) -> None:
         if not self._persist:
             self._offset2ids.clear()

--- a/docarray/array/storage/pqlite/seqlike.py
+++ b/docarray/array/storage/pqlite/seqlike.py
@@ -1,11 +1,12 @@
-from typing import Iterator, Union, Iterable, Sequence, MutableSequence
+from typing import Union, Iterable, Sequence
 
+from ..base.seqlike import BaseSequenceLikeMixin
 from .... import Document
 
 from ...memory import DocumentArrayInMemory
 
 
-class SequenceLikeMixin(MutableSequence['Document']):
+class SequenceLikeMixin(BaseSequenceLikeMixin):
     """Implement sequence-like methods"""
 
     def extend(self, values: Iterable['Document']) -> None:
@@ -49,3 +50,11 @@ class SequenceLikeMixin(MutableSequence['Document']):
         v = type(self)(self)
         v.extend(other)
         return v
+
+    def __contains__(self, x: Union[str, 'Document']):
+        if isinstance(x, str):
+            return self._pqlite.get_doc_by_id(x) is not None
+        elif isinstance(x, Document):
+            return self._pqlite.get_doc_by_id(x.id) is not None
+        else:
+            return False

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -103,6 +103,7 @@ class BackendMixin(BaseBackendMixin):
             else _sanitize_table_name(config.table_name)
         )
         self._persist = bool(config.table_name)
+        config.table_name = self._table_name
         initialize_table(
             self._table_name, self.__class__.__name__, self.schema_version, self._cursor
         )

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -61,7 +61,6 @@ class BackendMixin(BaseBackendMixin):
         config: Optional[Union[SqliteConfig, Dict]] = None,
         **kwargs,
     ):
-        super()._init_storage()
         if not config:
             config = SqliteConfig()
 
@@ -109,6 +108,9 @@ class BackendMixin(BaseBackendMixin):
         )
         self._connection.commit()
         self._config = config
+
+        super()._init_storage()
+
         from ... import DocumentArray
 
         if _docs is None:

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -61,6 +61,7 @@ class BackendMixin(BaseBackendMixin):
         config: Optional[Union[SqliteConfig, Dict]] = None,
         **kwargs,
     ):
+        super()._init_storage()
         if not config:
             config = SqliteConfig()
 

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -13,55 +13,12 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._sql(f'DELETE FROM {self._table_name} WHERE doc_id=?', (_id,))
         self._commit()
 
-    def _del_doc_by_offset(self, offset: int):
-
-        # if offset = -2 and len(self)= 100 use offset = 98
-        offset = len(self) + offset if offset < 0 else offset
-
-        self._sql(f'DELETE FROM {self._table_name} WHERE item_order=?', (offset,))
-
-        # shift the offset of every value on the right position of the deleted item
-        self._sql(
-            f'UPDATE {self._table_name} SET item_order=item_order-1 WHERE item_order>?',
-            (offset,),
-        )
-
-        # Code above line is equivalent to
-        """
-        for i in range(offset, len(self) + 1):
-            self._sql( f'UPDATE {self._table_name} SET item_order=? WHERE item_order=?',  (i - 1, i), )
-        """
-
-        self._commit()
-
-    def _set_doc_by_offset(self, offset: int, value: 'Document'):
-
-        # if offset = -2 and len(self)= 100 use offset = 98
-        offset = len(self) + offset if offset < 0 else offset
-
-        self._sql(
-            f'UPDATE {self._table_name} SET serialized_value=?, doc_id=? WHERE item_order=?',
-            (value, value.id, offset),
-        )
-
-        self._commit()
-
     def _set_doc_by_id(self, _id: str, value: 'Document'):
         self._sql(
             f'UPDATE {self._table_name} SET serialized_value=?, doc_id=? WHERE doc_id=?',
             (value, value.id, _id),
         )
         self._commit()
-
-    def _get_doc_by_offset(self, index: int) -> 'Document':
-        r = self._sql(
-            f'SELECT serialized_value FROM {self._table_name} WHERE item_order = ?',
-            (index + (len(self) if index < 0 else 0),),
-        )
-        res = r.fetchone()
-        if res is None:
-            raise IndexError('index out of range')
-        return res[0]
 
     def _get_doc_by_id(self, id: str) -> 'Document':
         r = self._sql(
@@ -76,17 +33,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     # now start the optimized bulk methods
     def _get_docs_by_offsets(self, offsets: Sequence[int]) -> Iterable['Document']:
-        l = len(self)
-        offsets = [o + (l if o < 0 else 0) for o in offsets]
-        r = self._sql(
-            f"SELECT serialized_value FROM {self._table_name} WHERE item_order in ({','.join(['?'] * len(offsets))})",
-            offsets,
-        )
-        for rr in r:
-            yield rr[0]
-
-    def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
-        return self._get_docs_by_offsets(range(len(self))[_slice])
+        ids = [self._offset2ids.get_id(offset) for offset in offsets]
+        return self._get_docs_by_ids(ids)
 
     def _get_docs_by_ids(self, ids: str) -> Iterable['Document']:
         r = self._sql(
@@ -96,23 +44,6 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         for rr in r:
             yield rr[0]
 
-    def _del_all_docs(self):
+    def _clear_storage(self):
         self._sql(f'DELETE FROM {self._table_name}')
-        self._commit()
-
-    def _del_docs_by_slice(self, _slice: slice):
-        offsets = range(len(self))[_slice]
-        self._sql(
-            f"DELETE FROM {self._table_name} WHERE item_order in ({','.join(['?'] * len(offsets))})",
-            offsets,
-        )
-        self._commit()
-
-    def _del_docs_by_mask(self, mask: Sequence[bool]):
-
-        offsets = [i for i, m in enumerate(mask) if m == True]
-        self._sql(
-            f"DELETE FROM {self._table_name} WHERE item_order in ({','.join(['?'] * len(offsets))})",
-            offsets,
-        )
         self._commit()

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -49,13 +49,6 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         )
         self._commit()
 
-    def _set_docs_by_ids(self, _id: str, value: 'Document'):
-        self._sql(
-            f'UPDATE {self._table_name} SET serialized_value=?, doc_id=? WHERE doc_id=?',
-            (value, value.id, _id),
-        )
-        self._commit()
-
     def _load_offset2ids(self):
         r = self._sql(
             f"SELECT doc_id FROM {self._table_name} ORDER BY item_order",

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -47,3 +47,17 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _clear_storage(self):
         self._sql(f'DELETE FROM {self._table_name}')
         self._commit()
+
+    def _del_docs_by_ids(self, ids: str) -> Iterable['Document']:
+        self._sql(
+            f"DELETE FROM {self._table_name} WHERE doc_id in ({','.join(['?'] * len(ids))})",
+            ids,
+        )
+        self._commit()
+
+    def _set_docs_by_ids(self, _id: str, value: 'Document'):
+        self._sql(
+            f'UPDATE {self._table_name} SET serialized_value=?, doc_id=? WHERE doc_id=?',
+            (value, value.id, _id),
+        )
+        self._commit()

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -64,14 +64,11 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._offset2ids.offset2id = list(map(itemgetter(0), r))
 
     def _save_offset2ids(self):
-        self._sql(
-            f"""
-            WITH Tmp(doc_id, item_order) AS (VALUES {','.join([
-                '(' + _id + ', ' + str(offset) + ')' for offset, _id in enumerate(self._offset2ids)
-            ])}
-            UPDATE {self._table_name} SET item_order = (SELECT item_order
-                                 FROM Tmp
-                                 WHERE {self._table_name}.doc_id = Tmp.doc_id)
-            """
-        )
+        for offset, doc_id in enumerate(self._offset2ids):
+            self._sql(
+                f"""
+                    UPDATE {self._table_name} SET item_order = ? WHERE {self._table_name}.doc_id = ?
+                """,
+                (offset, doc_id),
+            )
         self._commit()

--- a/docarray/array/storage/sqlite/seqlike.py
+++ b/docarray/array/storage/sqlite/seqlike.py
@@ -48,6 +48,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
         self._commit()
 
     def __del__(self) -> None:
+        super().__del__()
         if not self._persist:
             self._sql(
                 'DELETE FROM metadata WHERE table_name=? AND container_type=?',

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -55,6 +55,7 @@ class BackendMixin(BaseBackendMixin):
         :raises ValueError: only one of name or docs can be used for initialization,
             raise an error if both are provided
         """
+        super()._init_storage(_docs, **kwargs)
 
         if not config:
             raise ValueError('Config object must be specified')
@@ -81,7 +82,6 @@ class BackendMixin(BaseBackendMixin):
         self._config = config
 
         self._schemas = self._load_or_create_weaviate_schema()
-        self._offset2ids, self._offset2ids_wid = self._get_offset2ids_meta()
 
         _REGISTRY[self.__class__.__name__][self._class_name].append(self)
         # To align with Sqlite behavior; if `docs` is not `None` and table name

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -55,7 +55,6 @@ class BackendMixin(BaseBackendMixin):
         :raises ValueError: only one of name or docs can be used for initialization,
             raise an error if both are provided
         """
-        super()._init_storage(_docs, **kwargs)
 
         if not config:
             raise ValueError('Config object must be specified')
@@ -84,6 +83,9 @@ class BackendMixin(BaseBackendMixin):
         self._schemas = self._load_or_create_weaviate_schema()
 
         _REGISTRY[self.__class__.__name__][self._class_name].append(self)
+
+        super()._init_storage(_docs, **kwargs)
+
         # To align with Sqlite behavior; if `docs` is not `None` and table name
         # is provided, :class:`DocumentArraySqlite` will clear the existing
         # table and load the given `docs`

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -178,14 +178,14 @@ class BackendMixin(BaseBackendMixin):
             self._offset2ids_wid
         ):
             self._client.data_object.update(
-                data_object={'_offset2ids': self._offset2ids},
+                data_object={'_offset2ids': self._offset2ids.offset2id},
                 class_name=self._meta_name,
                 uuid=self._offset2ids_wid,
             )
         else:
             self._offset2ids_wid = str(uuid.uuid1())
             self._client.data_object.create(
-                data_object={'_offset2ids': self._offset2ids},
+                data_object={'_offset2ids': self._offset2ids.offset2id},
                 class_name=self._meta_name,
                 uuid=self._offset2ids_wid,
             )

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -1,4 +1,5 @@
 from ..base.getsetdel import BaseGetSetDelMixin
+from ..base.helper import Offset2ID
 from .... import Document
 
 
@@ -57,3 +58,10 @@ class GetSetDelMixin(BaseGetSetDelMixin):
             self._client.schema.delete_class(self._class_name)
             self._client.schema.delete_class(self._meta_name)
             self._load_or_create_weaviate_schema()
+
+    def _load_offset2ids(self):
+        self._offset2ids = Offset2ID()
+        self._offset2ids.offset2id, self._offset2ids_wid = self._get_offset2ids_meta()
+
+    def _save_offset2ids(self):
+        self._update_offset2ids_meta()

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -1,11 +1,3 @@
-import itertools
-from collections.abc import Iterable as _Iterable
-from typing import (
-    Sequence,
-    Iterable,
-    Any,
-)
-
 from ..base.getsetdel import BaseGetSetDelMixin
 from .... import Document
 

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -28,43 +28,6 @@ class GetSetDelMixin(BaseGetSetDelMixin):
             resp['properties']['_serialized'], **self._serialize_config
         )
 
-    def _setitem(self, wid: str, value: Document):
-        """Helper method for setting an item with weaviate as storage
-
-        :param wid: weaviate id
-        :param value: the new document to update to
-        """
-        payload = self._doc2weaviate_create_payload(value)
-        if self._client.data_object.exists(wid):
-            self._client.data_object.delete(wid)
-        self._client.data_object.create(**payload)
-        self._offset2ids[self._offset2ids.index(wid)] = self._wmap(value.id)
-        self._update_offset2ids_meta()
-
-    def _change_doc_id(self, old_wid: str, doc: Document, new_wid: str):
-        payload = self._doc2weaviate_create_payload(doc)
-        self._client.data_object.delete(old_wid)
-        self._client.data_object.create(**payload)
-        self._offset2ids[self._offset2ids.index(old_wid)] = new_wid
-        self._update_offset2ids_meta()
-
-    def _delitem(self, wid: str):
-        """Helper method for deleting an item with weaviate as storage
-
-        :param wid: weaviate id
-        """
-        self._client.data_object.delete(wid)
-        self._offset2ids.pop(self._offset2ids.index(wid))
-        self._update_offset2ids_meta()
-
-    def _get_doc_by_offset(self, offset: int) -> 'Document':
-        """Concrete implementation of base class' ``_get_doc_by_offset``
-
-        :param offset: the offset of the document in the list
-        :return: the retrieved document from weaviate
-        """
-        return self._getitem(self._offset2ids[offset])
-
     def _get_doc_by_id(self, _id: str) -> 'Document':
         """Concrete implementation of base class' ``_get_doc_by_id``
 
@@ -73,106 +36,32 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         """
         return self._getitem(self._wmap(_id))
 
-    def _get_docs_by_slice(self, _slice: slice) -> Iterable['Document']:
-        """Concrete implementation of base class' ``_get_doc_by_slice``
-
-        :param _slice: the slice of in the list to get docs from
-        :return: an iterable of retrieved documents from weaviate
-        """
-        wids = self._offset2ids[_slice]
-        return (self._getitem(wid) for wid in wids)
-
-    def _set_doc_by_offset(self, offset: int, value: 'Document'):
-        """Concrete implementation of base class' ``_set_doc_by_offset``
-
-        :param offset: the offset of doc in the list to update
-        :param value: the document to update to
-        """
-        wid = self._offset2ids[offset]
-        self._setitem(wid, value)
-        # update weaviate id
-        self._offset2ids[offset] = self._wmap(value.id)
-
     def _set_doc_by_id(self, _id: str, value: 'Document'):
         """Concrete implementation of base class' ``_set_doc_by_id``
 
         :param _id: the id of doc to update
         :param value: the document to update to
         """
-        self._setitem(self._wmap(_id), value)
-
-    def _set_docs_by_slice(self, _slice: slice, values: Sequence['Document']):
-        """Concrete implementation of base class' ``_set_doc_by_slice``
-
-        :param _slice: the slice of documents in the list to update
-        :param values: the documents to update to
-        :raises TypeError: error is raised if value is not an iterable because
-            docs indexed by slice is always an array
-        """
-        wids = self._offset2ids[_slice]
-        if not isinstance(values, _Iterable):
-            raise TypeError('can only assign an iterable')
-        for _i, _v in zip(wids, values):
-            self._setitem(_i, _v)
-
-    def _set_doc_attr_by_id(self, _id: str, attr: str, value: Any):
-        """Concrete implementation of base class' ``_set_doc_attr_by_id``
-
-        :param _id: the id of the document to update
-        :param attr: the attribute to update
-        :param value: the value to set doc's ``attr`` to
-        :raises ValueError: raise an error if user tries to pop the id of the doc
-        """
-        if attr == 'id' and value is None:
-            raise ValueError('pop id from Document stored with weaviate is not allowed')
-        doc = self[_id]
-
-        if attr == 'id':
-            old_wid = self._wmap(doc.id)
-            setattr(doc, attr, value)
-            self._change_doc_id(old_wid, doc, self._wmap(value))
-        else:
-            setattr(doc, attr, value)
-            self._setitem(self._wmap(doc.id), doc)
-
-    def _del_doc_by_offset(self, offset: int):
-        """Concrete implementation of base class' ``_del_doc_by_offset``
-
-        :param offset: the offset of the document to delete
-        """
-        self._delitem(self._offset2ids[offset])
+        if _id != value.id:
+            self._del_doc_by_id(_id)
+        wid = self._wmap(value.id)
+        payload = self._doc2weaviate_create_payload(value)
+        if self._client.data_object.exists(wid):
+            self._client.data_object.delete(wid)
+        self._client.data_object.create(**payload)
 
     def _del_doc_by_id(self, _id: str):
         """Concrete implementation of base class' ``_del_doc_by_id``
 
         :param _id: the id of the document to delete
         """
-        self._delitem(self._wmap(_id))
+        wid = self._wmap(_id)
+        if self._client.data_object.exists(wid):
+            self._client.data_object.delete(wid)
 
-    def _del_docs_by_slice(self, _slice: slice):
-        """Concrete implementation of base class' ``_del_doc_by_slice``
-
-        :param _slice: the slice of documents to delete
-        """
-        start = _slice.start or 0
-        stop = _slice.stop or len(self)
-        step = _slice.step or 1
-        del self[list(range(start, stop, step))]
-
-    def _del_all_docs(self):
-        """ Concrete implementation of base class' ``_del_all_docs``"""
+    def _clear_storage(self):
+        """ Concrete implementation of base class' ``_clear_storage``"""
         if self._class_name:
             self._client.schema.delete_class(self._class_name)
             self._client.schema.delete_class(self._meta_name)
-            self._offset2ids.clear()
             self._load_or_create_weaviate_schema()
-            self._update_offset2ids_meta()
-
-    def _del_docs_by_mask(self, mask: Sequence[bool]):
-        """Concrete implementation of base class' ``_del_docs_by_mask``
-
-        :param mask: the mask used for indexing which documents to delete
-        """
-        idxs = list(itertools.compress(self._offset2ids, (not _i for _i in mask)))
-        for _idx in reversed(idxs):
-            self._delitem(_idx)

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -56,7 +56,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
     def __del__(self):
         """Delete this :class:`DocumentArrayWeaviate` object"""
-        # TODO: persist offset2id here
+        super().__del__()
         if (
             not self._persist
             and len(_REGISTRY[self.__class__.__name__][self._class_name]) == 1

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -1,10 +1,11 @@
 from typing import Iterator, Union, Iterable, MutableSequence
 
+from ..base.seqlike import BaseSequenceLikeMixin
 from .... import Document
 from ..registry import _REGISTRY
 
 
-class SequenceLikeMixin(MutableSequence[Document]):
+class SequenceLikeMixin(BaseSequenceLikeMixin):
     """Implement sequence-like methods for DocumentArray with weaviate as storage"""
 
     def __eq__(self, other):

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -7,16 +7,6 @@ from ..registry import _REGISTRY
 class SequenceLikeMixin(MutableSequence[Document]):
     """Implement sequence-like methods for DocumentArray with weaviate as storage"""
 
-    def insert(self, index: int, value: 'Document'):
-        """Insert `doc` at `index`.
-
-        :param index: Position of the insertion.
-        :param value: The doc needs to be inserted.
-        """
-        self._offset2ids.insert(index, self._wmap(value.id))
-        self._client.data_object.create(**self._doc2weaviate_create_payload(value))
-        self._update_offset2ids_meta()
-
     def __eq__(self, other):
         """Compare this object to the other, returns True if and only if other
         as the same type as self and other has the same meta information
@@ -50,14 +40,6 @@ class SequenceLikeMixin(MutableSequence[Document]):
 
         return cls_data[0]['meta']['count']
 
-    def __iter__(self) -> Iterator['Document']:
-        """Iterate over all the root-level documents in the array
-
-        :yield: root-level document stored in this :class:`DocumentArrayWeaviate` object
-        """
-        for wid in range(len(self._offset2ids)):
-            yield self[wid]
-
     def __contains__(self, x: Union[str, 'Document']):
         """Check if ``x`` is contained in this :class:`DocumentArray` with weaviate storage
 
@@ -73,6 +55,7 @@ class SequenceLikeMixin(MutableSequence[Document]):
 
     def __del__(self):
         """Delete this :class:`DocumentArrayWeaviate` object"""
+        # TODO: persist offset2id here
         if (
             not self._persist
             and len(_REGISTRY[self.__class__.__name__][self._class_name]) == 1
@@ -80,16 +63,6 @@ class SequenceLikeMixin(MutableSequence[Document]):
             self._client.schema.delete_class(self._class_name)
             self._client.schema.delete_class(self._meta_name)
         _REGISTRY[self.__class__.__name__][self._class_name].remove(self)
-
-    def clear(self):
-        """Clear the data of :class:`DocumentArray` with weaviate storage"""
-        self._del_all_docs()
-
-    def __bool__(self):
-        """To simulate ```l = []; if l: ...```
-        :return: returns true if the length of the array is larger than 0
-        """
-        return len(self) > 0
 
     def __repr__(self):
         """Return the string representation of :class:`DocumentArrayWeaviate` object
@@ -105,5 +78,4 @@ class SequenceLikeMixin(MutableSequence[Document]):
         with self._client.batch(batch_size=50) as _b:
             for d in values:
                 _b.add_data_object(**self._doc2weaviate_create_payload(d))
-                self._offset2ids.append(self._wmap(d.id))
-        self._update_offset2ids_meta()
+                self._offset2ids.append(d.id)

--- a/docarray/array/storage/weaviate/seqlike.py
+++ b/docarray/array/storage/weaviate/seqlike.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Union, Iterable, MutableSequence
+from typing import Union, Iterable
 
 from ..base.seqlike import BaseSequenceLikeMixin
 from .... import Document

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
             'jupyterlab',
             'transformers==4.16.2',
             'weaviate-client~=3.3.0',
-            'pqlite>=0.2.3',
+            'pqlite>=0.2.4',
         ],
     },
     classifiers=[

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -4,6 +4,7 @@ import uuid
 import numpy as np
 import pytest
 
+from docarray import Document
 from docarray.array.memory import DocumentArrayInMemory
 from docarray.array.sqlite import DocumentArraySqlite
 from docarray.array.pqlite import DocumentArrayPqlite, PqliteConfig
@@ -34,6 +35,7 @@ def test_document_save_load(
 ):
     tmp_file = os.path.join(tmp_path, 'test')
     da = da_cls(docs, config=config())
+    da.insert(2, Document(id='new'))
     da.save(tmp_file, file_format=method, encoding=encoding)
 
     da_r = type(da).load(
@@ -42,6 +44,7 @@ def test_document_save_load(
 
     assert type(da) is type(da_r)
     assert len(da) == len(da_r)
+    assert da_r[2].id == 'new'
     for d, d_r in zip(da, da_r):
         assert d.id == d_r.id
         np.testing.assert_equal(d.embedding, d_r.embedding)

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -83,7 +83,7 @@ def test_setter_int_str(docs, storage, config, start_weaviate):
         ('pqlite', PqliteConfig(n_dim=123)),
     ],
 )
-def test_del_int_str(docs, storage, config, indices):
+def test_del_int_str(docs, storage, config, start_weaviate, indices):
     if config:
         docs = DocumentArray(docs, storage=storage, config=config)
     else:

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -537,11 +537,11 @@ def test_edge_case_two_strings(storage, config_gen, start_weaviate):
     assert len(da) == 3
     assert not da[1].text
 
-    if storage == 'weaviate':
-        with pytest.raises(
-            ValueError, match='pop id from Document stored with weaviate is not allowed'
-        ):
-            del da['1', 'id']
+    with pytest.raises(
+        ValueError,
+        match='pop id from Document stored in a DocumentArray is not allowed',
+    ):
+        del da['1', 'id']
 
     del da['2', 'hello']
 

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -539,7 +539,7 @@ def test_edge_case_two_strings(storage, config_gen, start_weaviate):
 
     with pytest.raises(
         ValueError,
-        match='pop id from Document stored in a DocumentArray is not allowed',
+        match='setting the ID of a Document stored in a DocumentArray to None is not allowed',
     ):
         del da['1', 'id']
 

--- a/tests/unit/array/test_base_getsetdel.py
+++ b/tests/unit/array/test_base_getsetdel.py
@@ -4,6 +4,7 @@ import pytest
 
 from docarray import DocumentArray, Document
 from docarray.array.storage.base.getsetdel import BaseGetSetDelMixin
+from docarray.array.storage.base.helper import Offset2ID
 from docarray.array.storage.memory import BackendMixin, SequenceLikeMixin
 
 
@@ -34,6 +35,12 @@ class StorageMixins(BackendMixin, DummyGetSetDelMixin, SequenceLikeMixin, ABC):
 class DocumentArrayDummy(StorageMixins, DocumentArray):
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls)
+
+    def _load_offset2ids(self):
+        self._offset2ids = Offset2ID()
+
+    def _save_offset2ids(self):
+        pass
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/array/test_base_getsetdel.py
+++ b/tests/unit/array/test_base_getsetdel.py
@@ -13,27 +13,18 @@ class DummyGetSetDelMixin(BaseGetSetDelMixin):
     # essentials
 
     def _del_doc_by_id(self, _id: str):
-        del self._data[self._id2offset[_id]]
-        self._id2offset.pop(_id)
-
-    def _del_doc_by_offset(self, offset: int):
-        self._id2offset.pop(self._data[offset].id)
-        del self._data[offset]
+        del self._data[_id]
 
     def _set_doc_by_id(self, _id: str, value: 'Document'):
-        old_idx = self._id2offset.pop(_id)
-        self._data[old_idx] = value
-        self._id2offset[value.id] = old_idx
-
-    def _get_doc_by_offset(self, offset: int) -> 'Document':
-        return self._data[offset]
+        if _id != value.id:
+            del self._data[_id]
+        self._data[value.id] = value
 
     def _get_doc_by_id(self, _id: str) -> 'Document':
-        return self._data[self._id2offset[_id]]
+        return self._data[_id]
 
-    def _set_doc_by_offset(self, offset: int, value: 'Document'):
-        self._data[offset] = value
-        self._id2offset[value.id] = offset
+    def _clear_storage(self):
+        self._data.clear()
 
 
 class StorageMixins(BackendMixin, DummyGetSetDelMixin, SequenceLikeMixin, ABC):

--- a/tests/unit/document/test_feature_hashing.py
+++ b/tests/unit/document/test_feature_hashing.py
@@ -1,14 +1,14 @@
 import pytest
 
-from docarray import DocumentArray
+from docarray import DocumentArray, Document
 from docarray.math.ndarray import to_numpy_array
 
 
-@pytest.mark.parametrize('n_dim', [2, 4, 100])
-@pytest.mark.parametrize('sparse', [True, False])
-@pytest.mark.parametrize('metric', ['jaccard', 'cosine'])
+@pytest.mark.parametrize('n_dim', [4])
+@pytest.mark.parametrize('sparse', [True])
+@pytest.mark.parametrize('metric', ['cosine'])
 def test_feature_hashing(n_dim, sparse, metric):
-    da = DocumentArray.empty(6)
+    da = DocumentArray([Document(id=str(i)) for i in range(6)])
     da.texts = [
         'hello world',
         'world, bye',
@@ -21,7 +21,6 @@ def test_feature_hashing(n_dim, sparse, metric):
     assert da.embeddings.shape == (6, n_dim)
     da.embeddings = to_numpy_array(da.embeddings)
     da.match(da, metric=metric, use_scipy=True)
-    result = da['@m', ('id', f'scores__{metric}__value')]
-    assert len(result) == 2
-    assert result[1][0] == 0.0
-    assert result[1][1] > 0.0
+    for doc in da:
+        assert doc.matches[0].scores[metric].value == pytest.approx(0.0)
+        assert doc.matches[1].scores[metric].value > 0.0


### PR DESCRIPTION
feat: use list for offset2id
Goal: Have a unified offset2id data structure for all storage backends and pull out the implementation details of all offset-related operations from the implementations of storage backends.

For now, we are relying on python list because all operations that we currently need will be delegated to built in methods of list: There shouldn't be any pure python for loops interacting with offset2ids.

TODOs:

- [x] fix tests for DocumentArrayInMemory
- [x] leverage offset2ids in DocumentArrayWeaviate
- [x] leverage offset2ids in DocumentArrayPQLite
- [x] leverage offset2ids in DocumentArraySqlite
- [x] take care of operations that can be done in batches (for example, pqlite allows batch updates), _del_docs_by_ids not implemented in base, ...
- [x] allow save/load of offset2ids on `__init__` and `__del__`
* weaviate: meta schema
* sqlite: use another column
* pqlite: sqlite table
- [x] __getstate__ and __setstate__ to also include offset2ids
- [x] TODOs
- [x] Update create storage backend documentation