### PR TITLE
fix: max_rel args in evaluation

### DIFF
--- a/docarray/array/mixins/evaluation.py
+++ b/docarray/array/mixins/evaluation.py
@@ -74,8 +74,7 @@ class EvaluationMixin:
 
             binary_relevance = [1 if hash_fn(m) in desired else 0 for m in d.matches]
 
-            if 'max_rel' not in kwargs:
-                kwargs['max_rel'] = len(gd.matches)
+            kwargs['max_rel'] = len(gd.matches)
 
             r = metric_fn(binary_relevance, **kwargs)
             d.evaluations[metric_name] = NamedScore(


### PR DESCRIPTION
Finetuner.fit internally calls docarray evaluation with all default metrics but with no arguments. This causes the `f1_score_at_k` and `recall_at_k` to fail as no `max_rel` argument is passed. It should be added to the kwargs at each iteration of the docs as not every doc has same number of matches