### PR TITLE
feat: add method to extract metadata information

### DIFF
--- a/docarray/array/mixins/getattr.py
+++ b/docarray/array/mixins/getattr.py
@@ -33,6 +33,7 @@ class GetAttributeMixin:
 
             if len(fields) == 1:
                 contents = [contents]
+
             if b_index is not None:
                 contents.insert(b_index, self.tensors)
             if e_index is not None:
@@ -49,3 +50,12 @@ class GetAttributeMixin:
                 if b_index > e_index
                 else [self.tensors, self.embeddings]
             )
+
+    def _get_attributes_information(self, *fields: str) -> List:
+        """Return information about the values of the fields from all docs this array contains
+
+        :param fields: Variable length argument with the name of the fields to extract
+        :return: Returns a list of information for these fields.
+            When `fields` has multiple values, then it returns a list of list.
+        """
+        pass


### PR DESCRIPTION
Refactor `_ipython_display_` to avoid https://github.com/jina-ai/docarray/issues/130 .

### problem

When plotting to a jupyter notebook `_ipython_display_` is called which calls `summary` which calls 
`all_attrs_values = self._get_attributes(*all_attrs_names)`.

- BUG 🐛: If there are `tensor` or `embedding` fields then `all_attrs_names` contains them. This implies `.tensors` or `.emdeddings` can be called which will break since data can't be stacked.
- PERFORMANCE REFACTOR: Even if the previous bug is solved it does not seem reasonable to load all embeddings in RAM just to get the length and if any of those elements is a None.

### Workaround Usability

When computing embedding stacking or .match it should be resilient to:
- `None` fields: In this case return correct result taking into account missing vectors.
- `dimension mismatch`: In this case throw and error.

### Workaround Performance

Never call  `.tensors` or `.emdeddings` which is actually quite dangerous for big datasets because it will allocate the memory for all the vectors. 

### Notes

I guess the behaviour could change in `DocumentArrayInmemory` vs the rest. Specially for `DocumentArray` with other storage backends (not memory) iterating over the data is infeasible for simply printing `DocumentArray` information. 