### PR TITLE
feat: add compression and protocol in file name

### DIFF
--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import os.path
+import os
 import pickle
 from contextlib import nullcontext
 from typing import Union, BinaryIO, TYPE_CHECKING, Type, Optional, Generator
@@ -10,7 +11,6 @@ from ....helper import (
     get_compress_ctx,
     decompress_bytes,
     protocol_and_compress_from_file_path,
-    add_protocol_and_compress_to_file_path,
 )
 
 if TYPE_CHECKING:
@@ -42,7 +42,15 @@ class BinaryIOMixin:
         :param streaming: if `True` returns a generator over `Document` objects.
         In case protocol is pickle the `Documents` are streamed from disk to save memory usage
         :return: a DocumentArray object
+
+        .. note::
+            If `file` is `str` it can specify `protocol` and `compress` as file extensions.
+            This functionality assumes `file=file_name.$protocol.$compress` where `$protocol` and `$compress` refer to a
+            string interpolation of the respective `protocol` and `compress` methods.
+            For example if `file=my_docarray.protobuf.lz4` then the binary data will be loaded assuming `protocol=protobuf`
+            and `compress=lz4`.
         """
+
         if isinstance(file, io.BufferedReader):
             file_ctx = nullcontext(file)
         elif isinstance(file, bytes):
@@ -62,6 +70,7 @@ class BinaryIOMixin:
                 _show_progress=_show_progress,
             )
         else:
+            print(protocol, compress)
             return cls._load_binary_all(
                 file_ctx, protocol, compress, _show_progress, *args, **kwargs
             )
@@ -200,21 +209,36 @@ class BinaryIOMixin:
     ) -> None:
         """Save array elements into a binary file.
 
+        :param file: File or filename to which the data is saved.
+        :param protocol: protocol to use
+        :param compress: compress algorithm to use
+
+         .. note::
+            If `file` is `str` it can specify `protocol` and `compress` as file extensions.
+            This functionality assumes `file=file_name.$protocol.$compress` where `$protocol` and `$compress` refer to a
+            string interpolation of the respective `protocol` and `compress` methods.
+            For example if `file=my_docarray.protobuf.lz4` then the binary data will be created using `protocol=protobuf`
+            and `compress=lz4`.
+
         Comparing to :meth:`save_json`, it is faster and the file is smaller, but not human-readable.
 
         .. note::
             To get a binary presentation in memory, use ``bytes(...)``.
 
-        :param protocol: protocol to use
-        :param compress: compress algorithm to use
-        :param file: File or filename to which the data is saved.
         """
         if isinstance(file, io.BufferedWriter):
             file_ctx = nullcontext(file)
         else:
-            file = add_protocol_and_compress_to_file_path(file, protocol, compress)
+            _protocol, _compress = protocol_and_compress_from_file_path(file)
+
+            if _protocol is not None:
+                protocol = _protocol
+            if _compress is not None:
+                compress = _compress
+
             file_ctx = open(file, 'wb')
 
+        print(protocol, compress)
         self.to_bytes(protocol=protocol, compress=compress, _file_ctx=file_ctx)
 
     def to_bytes(

--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -18,9 +18,6 @@ if TYPE_CHECKING:
     from ....proto.docarray_pb2 import DocumentArrayProto
     from .... import Document, DocumentArray
 
-ALLOWED_PROTOCOLS = {'pickle', 'protobuf', 'protobuf-array', 'pickle-array'}
-ALLOWED_COMPRESSIONS = {'lz4', 'bz2', 'lzma', 'zlib', 'gzip'}
-
 
 class BinaryIOMixin:
     """Save/load an array to a binary file."""

--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -5,7 +5,13 @@ import pickle
 from contextlib import nullcontext
 from typing import Union, BinaryIO, TYPE_CHECKING, Type, Optional, Generator
 
-from ....helper import __windows__, get_compress_ctx, decompress_bytes
+from ....helper import (
+    __windows__,
+    get_compress_ctx,
+    decompress_bytes,
+    protocol_and_compress_from_file_path,
+    add_protocol_and_compress_to_file_path,
+)
 
 if TYPE_CHECKING:
     from ....types import T
@@ -42,6 +48,9 @@ class BinaryIOMixin:
         elif isinstance(file, bytes):
             file_ctx = nullcontext(file)
         elif os.path.exists(file):
+            protocol, compress = protocol_and_compress_from_file_path(
+                file, protocol, compress
+            )
             file_ctx = open(file, 'rb')
         else:
             raise ValueError(f'unsupported input {file!r}')
@@ -203,6 +212,7 @@ class BinaryIOMixin:
         if isinstance(file, io.BufferedWriter):
             file_ctx = nullcontext(file)
         else:
+            file = add_protocol_and_compress_to_file_path(file, protocol, compress)
             file_ctx = open(file, 'wb')
 
         self.to_bytes(protocol=protocol, compress=compress, _file_ctx=file_ctx)

--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -70,7 +70,6 @@ class BinaryIOMixin:
                 _show_progress=_show_progress,
             )
         else:
-            print(protocol, compress)
             return cls._load_binary_all(
                 file_ctx, protocol, compress, _show_progress, *args, **kwargs
             )
@@ -238,7 +237,6 @@ class BinaryIOMixin:
 
             file_ctx = open(file, 'wb')
 
-        print(protocol, compress)
         self.to_bytes(protocol=protocol, compress=compress, _file_ctx=file_ctx)
 
     def to_bytes(

--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from ....proto.docarray_pb2 import DocumentArrayProto
     from .... import Document, DocumentArray
 
+ALLOWED_PROTOCOLS = {'pickle', 'protobuf', 'protobuf-array', 'pickle-array'}
+ALLOWED_COMPRESSIONS = {'lz4', 'bz2', 'lzma', 'zlib', 'gzip'}
+
 
 class BinaryIOMixin:
     """Save/load an array to a binary file."""

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -6,6 +6,8 @@ import pathlib
 import warnings
 from typing import Any, Dict, Optional, Sequence, Tuple
 
+from docarray.array.mixins.io.binary import ALLOWED_PROTOCOLS, ALLOWED_COMPRESSIONS
+
 __windows__ = sys.platform == 'win32'
 
 __resources_path__ = os.path.join(
@@ -346,9 +348,6 @@ def protocol_and_compress_from_file_path(
     >>> protocol_and_compress_from_file_path('/Documents/docarray_fashion_mnist.gzip')
     (None, gzip)
     """
-
-    ALLOWED_PROTOCOLS = {'pickle', 'protobuf', 'protobuf-array', 'pickle-array'}
-    ALLOWED_COMPRESSIONS = {'lz4', 'bz2', 'lzma', 'zlib', 'gzip'}
 
     protocol = default_protocol
     compress = default_compress

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -361,3 +361,30 @@ def protocol_and_compress_from_file_path(
             compress = extension
 
     return protocol, compress
+
+
+def add_protocol_and_compress_to_file_path(
+    file_path: str, protocol: Optional[str] = None, compress: Optional[str] = None
+) -> str:
+    """Creates a new file path with the protocol and compression methods as extensions.
+
+    :param file_path: path of a file.
+    :param protocol: chosen protocol.
+    :param compress: compression algorithm.
+
+    Examples:
+
+    >>> add_protocol_and_compress_to_file_path('docarray_fashion_mnist.bin')
+    'docarray_fashion_mnist.bin'
+
+    >>> add_protocol_and_compress_to_file_path('docarray_fashion_mnist', 'protobuf', 'gzip')
+    'docarray_fashion_mnist.protobuf.gzip'
+    """
+
+    file_path_extended = file_path
+    if protocol:
+        file_path_extended += '.' + protocol
+    if compress:
+        file_path_extended += '.' + compress
+
+    return file_path_extended

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -340,10 +340,10 @@ def protocol_and_compress_from_file_path(
 
     Examples:
 
-    >>> protocol_and_compress_from_file_path('./docarray_fashion_mnist.protobuff.gzip')
+    >>> protocol_and_compress_from_file_path('./docarray_fashion_mnist.protobuf.gzip')
     ('protobuf', 'gzip')
 
-    >>> protocol_and_compress_from_file_path('/Documents/docarray_fashion_mnist.protobuff')
+    >>> protocol_and_compress_from_file_path('/Documents/docarray_fashion_mnist.protobuf')
     ('protobuf', None)
 
     >>> protocol_and_compress_from_file_path('/Documents/docarray_fashion_mnist.gzip')
@@ -361,30 +361,3 @@ def protocol_and_compress_from_file_path(
             compress = extension
 
     return protocol, compress
-
-
-def add_protocol_and_compress_to_file_path(
-    file_path: str, protocol: Optional[str] = None, compress: Optional[str] = None
-) -> str:
-    """Creates a new file path with the protocol and compression methods as extensions.
-
-    :param file_path: path of a file.
-    :param protocol: chosen protocol.
-    :param compress: compression algorithm.
-
-    Examples:
-
-    >>> add_protocol_and_compress_to_file_path('docarray_fashion_mnist.bin')
-    'docarray_fashion_mnist.bin'
-
-    >>> add_protocol_and_compress_to_file_path('docarray_fashion_mnist', 'protobuf', 'gzip')
-    'docarray_fashion_mnist.protobuf.gzip'
-    """
-
-    file_path_extended = file_path
-    if protocol:
-        file_path_extended += '.' + protocol
-    if compress:
-        file_path_extended += '.' + compress
-
-    return file_path_extended

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -328,7 +328,7 @@ def protocol_and_compress_from_file_path(
     file_path: str,
     default_protocol: Optional[str] = None,
     default_compress: Optional[str] = None,
-) -> tuple[Optional[str], Opstional[str]]:
+) -> tuple[Optional[str], Optional[str]]:
     """Extract protocol and compression algorithm from a string, use defaults if not found.
 
     :param file_path: path of a file.

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -6,7 +6,8 @@ import pathlib
 import warnings
 from typing import Any, Dict, Optional, Sequence, Tuple
 
-from docarray.array.mixins.io.binary import ALLOWED_PROTOCOLS, ALLOWED_COMPRESSIONS
+ALLOWED_PROTOCOLS = {'pickle', 'protobuf', 'protobuf-array', 'pickle-array'}
+ALLOWED_COMPRESSIONS = {'lz4', 'bz2', 'lzma', 'zlib', 'gzip'}
 
 __windows__ = sys.platform == 'win32'
 

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -4,7 +4,7 @@ import sys
 import uuid
 import pathlib
 import warnings
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 __windows__ = sys.platform == 'win32'
 
@@ -328,7 +328,7 @@ def protocol_and_compress_from_file_path(
     file_path: str,
     default_protocol: Optional[str] = None,
     default_compress: Optional[str] = None,
-) -> tuple[Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[str]]:
     """Extract protocol and compression algorithm from a string, use defaults if not found.
 
     :param file_path: path of a file.

--- a/docs/fundamentals/documentarray/serialization.md
+++ b/docs/fundamentals/documentarray/serialization.md
@@ -164,8 +164,7 @@ The pattern `dock_bytes` and `dock.to_bytes` is repeated `len(docs)` times.
 
 ### From/to Disk
 
-If you want to store a `DocumentArray` to disk you can use `.save_binary(filename, protocol, compress)`
-where `protocol` and `compress` refer to the protocol and compression methods used to serialize the data.
+If you want to store a `DocumentArray` to disk you can use `.save_binary(filename, protocol, compress)` where `protocol` and `compress` refer to the protocol and compression methods used to serialize the data.
 If you want to load a `DocumentArray` from disk you can use `.load_binary(filename, protocol, compress)`.
 
 For example, the following snippet shows how to save/load a `DocumentArray` in `my_docarray.bin`.
@@ -180,11 +179,9 @@ da_rec = DocumentArray.load_binary('my_docarray.bin', protocol='protobuf', compr
 da_rec == da
 ```
 
-Note that in the previous code snippet the user needs to remember the protol and compression methods used to store the data
-in order to load it back correctly. `DocArray` allows you to specify `protocol` and `compress` as file extensions.
+Note that in the previous code snippet the user needs to remember the protol and compression methods used to store the data in order to load it back correctly. `DocArray` allows you to specify `protocol` and `compress` as file extensions.
 By doing so you can forget later on which protocol and compression methods were used to serialize the data to disk.
-This functionality assumes `.save_binary` and `.load_binary` are called with `filename` following the form
-`file_name.$protocol.$compress` where `$protocol` and `$compress` refer to a  string interpolation of the respective `protocol` and `compress` methods. 
+This functionality assumes `.save_binary` and `.load_binary` are called with `filename` following the form `file_name.$protocol.$compress`,  where `$protocol` and `$compress` refer to a  string interpolation of the respective `protocol` and `compress` methods. 
 
 For example if `file=my_docarray.protobuf.lz4` then the binary data will be created using `protocol=protobuf` and `compress=lz4`.
 
@@ -201,8 +198,8 @@ da_rec == da
 ```
 
 ```{tip}
-If you don't want to specify and remember `protocol` and `compress` to store to disk, save your `DocumentArray` `da` using 
-`da.save_binary('file_name.$protocol.$compress')` so that when loading you don't need to specify anything.
+If you don't want to specify and remember `protocol` and `compress` to store/load to/from disk, save your `DocumentArray` `da` using 
+`da.save_binary('file_name.$protocol.$compress')` so that it can be loaded back with `DocumentArray.load_binary('file_name.$protocol.$compress')`
 ```
 
 ### Stream large binary serialization from disk

--- a/docs/fundamentals/documentarray/serialization.md
+++ b/docs/fundamentals/documentarray/serialization.md
@@ -3,7 +3,7 @@
 
 DocArray is designed to be "ready-to-wire" at anytime. Serialization is important.
 DocumentArray provides multiple serialization methods that allows one transfer DocumentArray object over network and across different microservices.
-Moreover, there is the ability to store/load `DocumentArray` objects to disk.
+Moreover, there is the ability to store/load `DocumentArray` objects to/from disk.
 
 - JSON string: `.from_json()`/`.to_json()`
   - Pydantic model: `.from_pydantic_model()`/`.to_pydantic_model()`

--- a/docs/fundamentals/documentarray/serialization.md
+++ b/docs/fundamentals/documentarray/serialization.md
@@ -1,7 +1,9 @@
 (docarray-serialization)=
 # Serialization
 
-DocArray is designed to be "ready-to-wire" at anytime. Serialization is important. DocumentArray provides multiple serialization methods that allows one transfer DocumentArray object over network and across different microservices.
+DocArray is designed to be "ready-to-wire" at anytime. Serialization is important.
+DocumentArray provides multiple serialization methods that allows one transfer DocumentArray object over network and across different microservices.
+Moreover, there is the ability to store/load `DocumentArray` objects to disk.
 
 - JSON string: `.from_json()`/`.to_json()`
   - Pydantic model: `.from_pydantic_model()`/`.to_pydantic_model()`
@@ -11,7 +13,6 @@ DocArray is designed to be "ready-to-wire" at anytime. Serialization is importan
 - Python List: `.from_list()`/`.to_list()`
 - Pandas Dataframe: `.from_dataframe()`/`.to_dataframe()`
 - Cloud: `.push()`/`.pull()`
-
 
 
 
@@ -160,6 +161,49 @@ Here `version` is a `uint8` that specifies the serialization version of the `Doc
 Afterwards, `doc1_bytes` describes how many bytes are used to serialize `doc1`, followed by `doc1.to_bytes()` which is the bytes data of the document itself.
 The pattern `dock_bytes` and `dock.to_bytes` is repeated `len(docs)` times.
 
+
+### From/to Disk
+
+If you want to store a `DocumentArray` to disk you can use `.save_binary(filename, protocol, compress)`
+where `protocol` and `compress` refer to the protocol and compression methods used to serialize the data.
+If you want to load a `DocumentArray` from disk you can use `.load_binary(filename, protocol, compress)`.
+
+For example, the following snippet shows how to save/load a `DocumentArray` in `my_docarray.bin`.
+
+```python
+from docarray import DocumentArray, Document
+
+da = DocumentArray([Document(text='hello'), Document(text='world')])
+
+da.save_binary('my_docarray.bin', protocol='protobuf', compress='lz4')
+da_rec = DocumentArray.load_binary('my_docarray.bin', protocol='protobuf', compress='lz4')
+da_rec == da
+```
+
+Note that in the previous code snippet the user needs to remember the protol and compression methods used to store the data
+in order to load it back correctly. `DocArray` allows you to specify `protocol` and `compress` as file extensions.
+By doing so you can forget later on which protocol and compression methods were used to serialize the data to disk.
+This functionality assumes `.save_binary` and `.load_binary` are called with `filename` following the form
+`file_name.$protocol.$compress` where `$protocol` and `$compress` refer to a  string interpolation of the respective `protocol` and `compress` methods. 
+
+For example if `file=my_docarray.protobuf.lz4` then the binary data will be created using `protocol=protobuf` and `compress=lz4`.
+
+The previous code snippet can be simplified to 
+
+```python
+from docarray import DocumentArray, Document
+
+da = DocumentArray([Document(text='hello'), Document(text='world')])
+
+da.save_binary('my_docarray.protobuf.lz4')
+da_rec = DocumentArray.load_binary('my_docarray.protobuf.lz4')
+da_rec == da
+```
+
+```{tip}
+If you don't want to specify and remember `protocol` and `compress` to store to disk, save your `DocumentArray` `da` using 
+`da.save_binary('file_name.$protocol.$compress')` so that when loading you don't need to specify anything.
+```
 
 ### Stream large binary serialization from disk
 

--- a/docs/fundamentals/documentarray/serialization.md
+++ b/docs/fundamentals/documentarray/serialization.md
@@ -8,6 +8,7 @@ Moreover, there is the ability to store/load `DocumentArray` objects to disk.
 - JSON string: `.from_json()`/`.to_json()`
   - Pydantic model: `.from_pydantic_model()`/`.to_pydantic_model()`
 - Bytes (compressed): `.from_bytes()`/`.to_bytes()`
+  - Disk serialization: `.save_binary()`/`.load_binary()`
 - Base64 (compressed): `.from_base64()`/`.to_base64()` 
 - Protobuf Message: `.from_protobuf()`/`.to_protobuf()`
 - Python List: `.from_list()`/`.to_list()`

--- a/tests/unit/array/test_from_to_bytes.py
+++ b/tests/unit/array/test_from_to_bytes.py
@@ -106,6 +106,10 @@ def test_save_bytes_stream(tmpfile, protocol, compress):
         [Document(text='aaa'), Document(text='bbb'), Document(text='ccc')]
     )
     da.save_binary(tmpfile, protocol=protocol, compress=compress)
+
+    # note that save_binary will save protocol and compression in the filename
+    tmpfile += '.' + protocol + '.' + compress
+
     da_reconstructed = DocumentArray.load_binary(
         tmpfile, protocol=protocol, compress=compress, streaming=True
     )

--- a/tests/unit/array/test_from_to_bytes.py
+++ b/tests/unit/array/test_from_to_bytes.py
@@ -107,12 +107,6 @@ def test_save_bytes_stream(tmpfile, protocol, compress):
     )
     da.save_binary(tmpfile, protocol=protocol, compress=compress)
 
-    # note that save_binary will save protocol and compression in the filename
-    if protocol:
-        tmpfile += '.' + protocol
-    if compress:
-        tmpfile += '.' + compress
-
     da_reconstructed = DocumentArray.load_binary(
         tmpfile, protocol=protocol, compress=compress, streaming=True
     )

--- a/tests/unit/array/test_from_to_bytes.py
+++ b/tests/unit/array/test_from_to_bytes.py
@@ -11,6 +11,9 @@ from docarray.math.ndarray import to_numpy_array
 from tests import random_docs
 
 
+from docarray.helper import add_protocol_and_compress_to_file_path
+
+
 def get_ndarrays_for_ravel():
     a = np.random.random([100, 3])
     a[a > 0.5] = 0
@@ -60,16 +63,29 @@ def test_to_from_bytes(target_da, protocol, compress, ndarray_val, is_sparse):
 )
 @pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip', None])
 def test_save_bytes(target_da, protocol, compress, tmpfile):
+
+    # tests .save_binary(file, protocol=protocol, compress=compress)
     target_da.save_binary(tmpfile, protocol=protocol, compress=compress)
     target_da.save_binary(str(tmpfile), protocol=protocol, compress=compress)
 
     with open(tmpfile, 'wb') as fp:
         target_da.save_binary(fp, protocol=protocol, compress=compress)
 
-    DocumentArray.load_binary(tmpfile, protocol=protocol, compress=compress)
+    da_from_protocol_compress = DocumentArray.load_binary(
+        tmpfile, protocol=protocol, compress=compress
+    )
     DocumentArray.load_binary(str(tmpfile), protocol=protocol, compress=compress)
     with open(tmpfile, 'rb') as fp:
         DocumentArray.load_binary(fp, protocol=protocol, compress=compress)
+
+    # tests .save_binary(file.protocol.compress) without arguments `compression` and `protocol`
+    file_path_extended = add_protocol_and_compress_to_file_path(
+        str(tmpfile), protocol, compress
+    )
+
+    target_da.save_binary(file_path_extended)
+    da_from_file_extension = DocumentArray.load_binary(file_path_extended)
+    assert da_from_protocol_compress == da_from_file_extension
 
 
 @pytest.mark.parametrize('target_da', [DocumentArray.empty(100), random_docs(100)])

--- a/tests/unit/array/test_from_to_bytes.py
+++ b/tests/unit/array/test_from_to_bytes.py
@@ -108,7 +108,10 @@ def test_save_bytes_stream(tmpfile, protocol, compress):
     da.save_binary(tmpfile, protocol=protocol, compress=compress)
 
     # note that save_binary will save protocol and compression in the filename
-    tmpfile += '.' + protocol + '.' + compress
+    if protocol:
+        tmpfile += '.' + protocol
+    if compress:
+        tmpfile += '.' + compress
 
     da_reconstructed = DocumentArray.load_binary(
         tmpfile, protocol=protocol, compress=compress, streaming=True

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,4 +1,5 @@
 import pytest
+import pathlib
 
 from docarray.helper import (
     protocol_and_compress_from_file_path,

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -2,6 +2,7 @@ import pytest
 
 from docarray.helper import (
     protocol_and_compress_from_file_path,
+    add_protocol_and_compress_to_file_path,
 )
 
 
@@ -27,3 +28,22 @@ def test_protocol_and_compress_from_file_path(file_path, protocol, compress):
 
     assert protocol == _protocol
     assert compress == _compress
+
+
+@pytest.mark.parametrize('file_path', ['doc_array', './some_folder/doc_array'])
+@pytest.mark.parametrize(
+    'protocol', ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
+)
+@pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip'])
+def test_add_protocol_and_compress_to_file_path(file_path, compress, protocol):
+    file_path_extended = add_protocol_and_compress_to_file_path(
+        file_path, compress, protocol
+    )
+    file_path_suffixes = [
+        e.replace('.', '') for e in pathlib.Path(file_path_extended).suffixes
+    ]
+
+    if compress:
+        assert compress in file_path_suffixes
+    if protocol:
+        assert protocol in file_path_suffixes

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,29 +1,8 @@
 import pytest
-import pathlib
 
 from docarray.helper import (
-    add_protocol_and_compress_to_file_path,
     protocol_and_compress_from_file_path,
 )
-
-
-@pytest.mark.parametrize('file_path', ['doc_array', './some_folder/doc_array'])
-@pytest.mark.parametrize(
-    'protocol', ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
-)
-@pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip'])
-def test_add_protocol_and_compress_to_file_path(file_path, compress, protocol):
-    file_path_extended = add_protocol_and_compress_to_file_path(
-        file_path, compress, protocol
-    )
-    file_path_suffixes = [
-        e.replace('.', '') for e in pathlib.Path(file_path_extended).suffixes
-    ]
-
-    if compress:
-        assert compress in file_path_suffixes
-    if protocol:
-        assert protocol in file_path_suffixes
 
 
 @pytest.mark.parametrize(
@@ -41,8 +20,10 @@ def test_protocol_and_compress_from_file_path(file_path, protocol, compress):
     if compress:
         file_path_extended += '.' + compress
 
-    protocol, compress = protocol_and_compress_from_file_path(file_path_extended)
-    if protocol:
-        assert protocol in ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
-    if compress:
-        assert compress in ['lz4', 'bz2', 'lzma', 'zlib', 'gzip']
+    _protocol, _compress = protocol_and_compress_from_file_path(file_path_extended)
+
+    assert _protocol in {'protobuf', 'protobuf-array', 'pickle', 'pickle-array', None}
+    assert _compress in {'lz4', 'bz2', 'lzma', 'zlib', 'gzip', None}
+
+    assert protocol == _protocol
+    assert compress == _compress

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,0 +1,48 @@
+import pytest
+import pathlib
+
+from docarray.helper import (
+    add_protocol_and_compress_to_file_path,
+    protocol_and_compress_from_file_path,
+)
+
+
+@pytest.mark.parametrize('file_path', ['doc_array', './some_folder/doc_array'])
+@pytest.mark.parametrize(
+    'protocol', ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
+)
+@pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip'])
+def test_add_protocol_and_compress_to_file_path(file_path, compress, protocol):
+    file_path_extended = add_protocol_and_compress_to_file_path(
+        file_path, compress, protocol
+    )
+    file_path_suffixes = [
+        e.replace('.', '') for e in pathlib.Path(file_path_extended).suffixes
+    ]
+
+    if compress:
+        assert compress in file_path_suffixes
+    if protocol:
+        assert protocol in file_path_suffixes
+
+
+@pytest.mark.parametrize(
+    'file_path', ['doc_array', '../docarray', './a_folder/docarray']
+)
+@pytest.mark.parametrize(
+    'protocol', ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
+)
+@pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip', None])
+def test_protocol_and_compress_from_file_path(file_path, protocol, compress):
+
+    file_path_extended = file_path
+    if protocol:
+        file_path_extended += '.' + protocol
+    if compress:
+        file_path_extended += '.' + compress
+
+    protocol, compress = protocol_and_compress_from_file_path(file_path_extended)
+    if protocol:
+        assert protocol in ['protobuf', 'protobuf-array', 'pickle', 'pickle-array']
+    if compress:
+        assert compress in ['lz4', 'bz2', 'lzma', 'zlib', 'gzip']


### PR DESCRIPTION
Now there is the issue that if a `DocumentArray` is stored as binary users need to remember compression and protocol to load it back.

This PR adds this information as extensions in the file.

Example
```python
da = DocumentArray([Document(tensor=np.array([1,2,3])),  Document(tensor=np.array([7,8,9]))])
da.save_binary( 'my_docarray.protobuf.lz4')
```
will save
```bash
my_docarray.protobuf.lz4
```
Thefore,  later on users don't need to recall which `protocol` and `compress` were used. 
Since the information is in the string this PR parses it so that users don't need to pass this info as keyword arguments to `load_binary`. They can simply do:

```python
da.load_binary('my_docarray.protobuf.lz4')
```

This PR solves https://github.com/jina-ai/docarray/issues/128