### PR TITLE
refactor(graphql): strawberry to input

### DIFF
--- a/docarray/document/mixins/strawberry.py
+++ b/docarray/document/mixins/strawberry.py
@@ -13,7 +13,7 @@ class StrawberryMixin:
     def to_strawberry_type(self) -> 'StrawberryDocument':
         """Convert a Document object into a Strawberry type."""
         from ..strawberry_type import StrawberryDocument as SD
-        from ..strawberry_type import NameScoreItem, NamedScore
+        from ..strawberry_type import _NameScoreItem, _NamedScore
 
         _p_dict = {}
         for f in self.non_empty_fields:
@@ -22,7 +22,7 @@ class StrawberryMixin:
                 _p_dict[f] = v.to_strawberry_type()
             elif f in ('scores', 'evaluations'):
                 _p_dict[f] = [
-                    NameScoreItem(k, NamedScore(**v.to_dict())) for k, v in v.items()
+                    _NameScoreItem(k, _NamedScore(**v.to_dict())) for k, v in v.items()
                 ]
 
             else:

--- a/docarray/document/mixins/strawberry.py
+++ b/docarray/document/mixins/strawberry.py
@@ -13,7 +13,7 @@ class StrawberryMixin:
     def to_strawberry_type(self) -> 'StrawberryDocument':
         """Convert a Document object into a Strawberry type."""
         from ..strawberry_type import StrawberryDocument as SD
-        from ..strawberry_type import _NameScoreItem, _NamedScore
+        from ..strawberry_type import NameScoreItem, NamedScore
 
         _p_dict = {}
         for f in self.non_empty_fields:
@@ -22,7 +22,7 @@ class StrawberryMixin:
                 _p_dict[f] = v.to_strawberry_type()
             elif f in ('scores', 'evaluations'):
                 _p_dict[f] = [
-                    _NameScoreItem(k, _NamedScore(**v.to_dict())) for k, v in v.items()
+                    NameScoreItem(k, NamedScore(**v.to_dict())) for k, v in v.items()
                 ]
 
             else:

--- a/docarray/document/strawberry_type.py
+++ b/docarray/document/strawberry_type.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import List, Dict, Union, NewType, Any, Optional
+from typing import List, Dict, Union, NewType, Any, Optional, Callable
 
 import numpy as np
 import strawberry
@@ -33,7 +33,6 @@ NdArray = strawberry.scalar(
 )
 
 
-@strawberry.input
 class _NamedScore:
     value: Optional[float] = None
     op_name: Optional[str] = None
@@ -41,30 +40,42 @@ class _NamedScore:
     ref_id: Optional[str] = None
 
 
-@strawberry.input
+NamedScore = strawberry.type(_NamedScore)
+
+
 class _NameScoreItem:
     name: str
     score: _NamedScore
 
 
-@strawberry.input
-class StrawberryDocument:
-    id: Optional[str] = None
-    parent_id: Optional[str] = None
-    granularity: Optional[int] = None
-    adjacency: Optional[int] = None
-    blob: Optional[Base64] = None
-    tensor: Optional[NdArray] = None
-    mime_type: Optional[str] = None
-    text: Optional[str] = None
-    weight: Optional[float] = None
-    uri: Optional[str] = None
-    tags: Optional[JSONScalar] = None
-    offset: Optional[float] = None
-    location: Optional[List[float]] = None
-    embedding: Optional[NdArray] = None
-    modality: Optional[str] = None
-    evaluations: Optional[List[_NameScoreItem]] = None
-    scores: Optional[List[_NameScoreItem]] = None
-    chunks: Optional[List['StrawberryDocument']] = None
-    matches: Optional[List['StrawberryDocument']] = None
+NameScoreItem = strawberry.type(_NameScoreItem)
+
+
+def get_strwaberry_doc_object(strawberry_wrapper: Callable):
+    @strawberry_wrapper
+    class StrawberryDocumentObject:
+        id: Optional[str] = None
+        parent_id: Optional[str] = None
+        granularity: Optional[int] = None
+        adjacency: Optional[int] = None
+        blob: Optional[Base64] = None
+        tensor: Optional[NdArray] = None
+        mime_type: Optional[str] = None
+        text: Optional[str] = None
+        weight: Optional[float] = None
+        uri: Optional[str] = None
+        tags: Optional[JSONScalar] = None
+        offset: Optional[float] = None
+        location: Optional[List[float]] = None
+        embedding: Optional[NdArray] = None
+        modality: Optional[str] = None
+        evaluations: Optional[List[strawberry_wrapper(_NameScoreItem)]] = None
+        scores: Optional[List[strawberry_wrapper(_NameScoreItem)]] = None
+        chunks: Optional[List['StrawberryDocument']] = None
+        matches: Optional[List['StrawberryDocument']] = None
+
+    return StrawberryDocumentObject
+
+
+StrawberryDocument = get_strwaberry_doc_object(strawberry.type)
+StrawberryDocumentInput = get_strwaberry_doc_object(strawberry.input)

--- a/docarray/document/strawberry_type.py
+++ b/docarray/document/strawberry_type.py
@@ -33,7 +33,7 @@ NdArray = strawberry.scalar(
 )
 
 
-@strawberry.input
+@strawberry.type
 class _NamedScore:
     value: Optional[float] = None
     op_name: Optional[str] = None
@@ -41,13 +41,13 @@ class _NamedScore:
     ref_id: Optional[str] = None
 
 
-@strawberry.input
+@strawberry.type
 class _NameScoreItem:
     name: str
     score: _NamedScore
 
 
-@strawberry.input
+@strawberry.type
 class StrawberryDocument:
     id: Optional[str] = None
     parent_id: Optional[str] = None
@@ -68,3 +68,40 @@ class StrawberryDocument:
     scores: Optional[List[_NameScoreItem]] = None
     chunks: Optional[List['StrawberryDocument']] = None
     matches: Optional[List['StrawberryDocument']] = None
+
+
+@strawberry.input
+class _NamedScoreInput:
+    value: Optional[float] = None
+    op_name: Optional[str] = None
+    description: Optional[str] = None
+    ref_id: Optional[str] = None
+
+
+@strawberry.input
+class _NameScoreItemInput:
+    name: str
+    score: _NamedScoreInput
+
+
+@strawberry.input
+class StrawberryDocumentInput:
+    id: Optional[str] = None
+    parent_id: Optional[str] = None
+    granularity: Optional[int] = None
+    adjacency: Optional[int] = None
+    blob: Optional[Base64] = None
+    tensor: Optional[NdArray] = None
+    mime_type: Optional[str] = None
+    text: Optional[str] = None
+    weight: Optional[float] = None
+    uri: Optional[str] = None
+    tags: Optional[JSONScalar] = None
+    offset: Optional[float] = None
+    location: Optional[List[float]] = None
+    embedding: Optional[NdArray] = None
+    modality: Optional[str] = None
+    evaluations: Optional[List[_NameScoreItemInput]] = None
+    scores: Optional[List[_NameScoreItemInput]] = None
+    chunks: Optional[List['StrawberryDocumentInput']] = None
+    matches: Optional[List['StrawberryDocumentInput']] = None

--- a/docarray/document/strawberry_type.py
+++ b/docarray/document/strawberry_type.py
@@ -33,12 +33,42 @@ NdArray = strawberry.scalar(
 )
 
 
-@strawberry.type
-class _NamedScore:
+### interface
+
+
+@strawberry.interface
+class _NamedScoreInterface:
     value: Optional[float] = None
     op_name: Optional[str] = None
     description: Optional[str] = None
     ref_id: Optional[str] = None
+
+
+@strawberry.interface
+class _BaseStrawberryDocumentInterface:
+    id: Optional[str] = None
+    parent_id: Optional[str] = None
+    granularity: Optional[int] = None
+    adjacency: Optional[int] = None
+    blob: Optional[Base64] = None
+    tensor: Optional[NdArray] = None
+    mime_type: Optional[str] = None
+    text: Optional[str] = None
+    weight: Optional[float] = None
+    uri: Optional[str] = None
+    tags: Optional[JSONScalar] = None
+    offset: Optional[float] = None
+    location: Optional[List[float]] = None
+    embedding: Optional[NdArray] = None
+    modality: Optional[str] = None
+
+
+### type
+
+
+@strawberry.type
+class _NamedScore(_NamedScoreInterface):
+    ...
 
 
 @strawberry.type
@@ -48,34 +78,19 @@ class _NameScoreItem:
 
 
 @strawberry.type
-class StrawberryDocument:
-    id: Optional[str] = None
-    parent_id: Optional[str] = None
-    granularity: Optional[int] = None
-    adjacency: Optional[int] = None
-    blob: Optional[Base64] = None
-    tensor: Optional[NdArray] = None
-    mime_type: Optional[str] = None
-    text: Optional[str] = None
-    weight: Optional[float] = None
-    uri: Optional[str] = None
-    tags: Optional[JSONScalar] = None
-    offset: Optional[float] = None
-    location: Optional[List[float]] = None
-    embedding: Optional[NdArray] = None
-    modality: Optional[str] = None
+class StrawberryDocument(strawberry.type(_BaseStrawberryDocumentInterface)):
     evaluations: Optional[List[_NameScoreItem]] = None
     scores: Optional[List[_NameScoreItem]] = None
     chunks: Optional[List['StrawberryDocument']] = None
     matches: Optional[List['StrawberryDocument']] = None
 
 
+### input
+
+
 @strawberry.input
-class _NamedScoreInput:
-    value: Optional[float] = None
-    op_name: Optional[str] = None
-    description: Optional[str] = None
-    ref_id: Optional[str] = None
+class _NamedScoreInput(_NamedScoreInterface):
+    ...
 
 
 @strawberry.input
@@ -85,22 +100,7 @@ class _NameScoreItemInput:
 
 
 @strawberry.input
-class StrawberryDocumentInput:
-    id: Optional[str] = None
-    parent_id: Optional[str] = None
-    granularity: Optional[int] = None
-    adjacency: Optional[int] = None
-    blob: Optional[Base64] = None
-    tensor: Optional[NdArray] = None
-    mime_type: Optional[str] = None
-    text: Optional[str] = None
-    weight: Optional[float] = None
-    uri: Optional[str] = None
-    tags: Optional[JSONScalar] = None
-    offset: Optional[float] = None
-    location: Optional[List[float]] = None
-    embedding: Optional[NdArray] = None
-    modality: Optional[str] = None
+class StrawberryDocumentInput(strawberry.input(_BaseStrawberryDocumentInterface)):
     evaluations: Optional[List[_NameScoreItemInput]] = None
     scores: Optional[List[_NameScoreItemInput]] = None
     chunks: Optional[List['StrawberryDocumentInput']] = None

--- a/docarray/document/strawberry_type.py
+++ b/docarray/document/strawberry_type.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import List, Dict, Union, NewType, Any, Optional, Callable
+from typing import List, Dict, Union, NewType, Any, Optional
 
 import numpy as np
 import strawberry
@@ -33,6 +33,7 @@ NdArray = strawberry.scalar(
 )
 
 
+@strawberry.input
 class _NamedScore:
     value: Optional[float] = None
     op_name: Optional[str] = None
@@ -40,42 +41,30 @@ class _NamedScore:
     ref_id: Optional[str] = None
 
 
-NamedScore = strawberry.type(_NamedScore)
-
-
+@strawberry.input
 class _NameScoreItem:
     name: str
     score: _NamedScore
 
 
-NameScoreItem = strawberry.type(_NameScoreItem)
-
-
-def get_strwaberry_doc_object(strawberry_wrapper: Callable):
-    @strawberry_wrapper
-    class StrawberryDocumentObject:
-        id: Optional[str] = None
-        parent_id: Optional[str] = None
-        granularity: Optional[int] = None
-        adjacency: Optional[int] = None
-        blob: Optional[Base64] = None
-        tensor: Optional[NdArray] = None
-        mime_type: Optional[str] = None
-        text: Optional[str] = None
-        weight: Optional[float] = None
-        uri: Optional[str] = None
-        tags: Optional[JSONScalar] = None
-        offset: Optional[float] = None
-        location: Optional[List[float]] = None
-        embedding: Optional[NdArray] = None
-        modality: Optional[str] = None
-        evaluations: Optional[List[strawberry_wrapper(_NameScoreItem)]] = None
-        scores: Optional[List[strawberry_wrapper(_NameScoreItem)]] = None
-        chunks: Optional[List['StrawberryDocument']] = None
-        matches: Optional[List['StrawberryDocument']] = None
-
-    return StrawberryDocumentObject
-
-
-StrawberryDocument = get_strwaberry_doc_object(strawberry.type)
-StrawberryDocumentInput = get_strwaberry_doc_object(strawberry.input)
+@strawberry.input
+class StrawberryDocument:
+    id: Optional[str] = None
+    parent_id: Optional[str] = None
+    granularity: Optional[int] = None
+    adjacency: Optional[int] = None
+    blob: Optional[Base64] = None
+    tensor: Optional[NdArray] = None
+    mime_type: Optional[str] = None
+    text: Optional[str] = None
+    weight: Optional[float] = None
+    uri: Optional[str] = None
+    tags: Optional[JSONScalar] = None
+    offset: Optional[float] = None
+    location: Optional[List[float]] = None
+    embedding: Optional[NdArray] = None
+    modality: Optional[str] = None
+    evaluations: Optional[List[_NameScoreItem]] = None
+    scores: Optional[List[_NameScoreItem]] = None
+    chunks: Optional[List['StrawberryDocument']] = None
+    matches: Optional[List['StrawberryDocument']] = None

--- a/docarray/document/strawberry_type.py
+++ b/docarray/document/strawberry_type.py
@@ -33,7 +33,7 @@ NdArray = strawberry.scalar(
 )
 
 
-@strawberry.type
+@strawberry.input
 class _NamedScore:
     value: Optional[float] = None
     op_name: Optional[str] = None
@@ -41,13 +41,13 @@ class _NamedScore:
     ref_id: Optional[str] = None
 
 
-@strawberry.type
+@strawberry.input
 class _NameScoreItem:
     name: str
     score: _NamedScore
 
 
-@strawberry.type
+@strawberry.input
 class StrawberryDocument:
     id: Optional[str] = None
     parent_id: Optional[str] = None


### PR DESCRIPTION
We need both strawberry `input` and `type` for `DocumentArray`.

Indeed in strawberry [input](https://strawberry.rocks/docs/types/input-types) and [type](https://strawberry.rocks/docs/types/object-types) are two differents concepts (even if from a code perspective they are very similar).

Briefly : 

* `type` is used to select fields in request / response
* ` input` is used  when "posting" a document. (We need it in core because we always rely on posting a da when calling an endpoint)

So core need both definition in `docarray`. Moreover other users working with docarray might need both as well.

Right now we defined `StrawberryDocumentInput` without correlation with `StrawberryDocument`(the type). So some code is repeated. This is normal, both objects and semantically different even if today they are almost equal it could be different in the future. ( see this  [commit](https://github.com/jina-ai/docarray/pull/114/commits/ecc648866cfd354e3461cd94d1b1c7126b17ba99) where I unified both that I finally revert)

original conversion [here](https://github.com/jina-ai/docarray/pull/114)

done with @JohannesMessner 
