### PR TITLE
feat: query language supporting filter

### DIFF
--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -159,7 +159,7 @@ class FindMixin:
     ) -> Tuple['np.ndarray', 'np.ndarray']:
         raise NotImplementedError
 
-    def filter(self, *args, **kwargs):
+    def _filter(self, *args, **kwargs):
         from ... import DocumentArray
         from ...lookup import Q, filter_items
 

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -159,9 +159,10 @@ class FindMixin:
     ) -> Tuple['np.ndarray', 'np.ndarray']:
         raise NotImplementedError
 
-    def _filter(self, *args, **kwargs):
+    def _filter(self, query: Dict, **kwargs):
         from ... import DocumentArray
-        from docarray.array.queryset.lookup import filter_items
+        from docarray.array.queryset.parser import QueryParser
 
-        result = filter_items(self, *args, **kwargs)
-        return DocumentArray(result)
+        parser = QueryParser(query)
+
+        return DocumentArray([d for d in self if parser.evaluate(d)])

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -158,3 +158,10 @@ class FindMixin:
         self, query: 'ArrayType', limit: int, **kwargs
     ) -> Tuple['np.ndarray', 'np.ndarray']:
         raise NotImplementedError
+
+    def filter(self, *args, **kwargs):
+        from ... import DocumentArray
+        from ...lookup import Q, filter_items
+
+        result = filter_items(self, *args, **kwargs)
+        return DocumentArray(result)

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -36,7 +36,7 @@ class FindMixin:
 
     def find(
         self: 'T',
-        query: Union['DocumentArray', 'Document', 'ArrayType'],
+        query: Union['DocumentArray', 'Document', 'ArrayType', Dict],
         metric: Union[
             str, Callable[['ArrayType', 'ArrayType'], 'np.ndarray']
         ] = 'cosine',

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -161,7 +161,7 @@ class FindMixin:
 
     def _filter(self, *args, **kwargs):
         from ... import DocumentArray
-        from ...lookup import Q, filter_items
+        from docarray.array.queryset.lookup import filter_items
 
         result = filter_items(self, *args, **kwargs)
         return DocumentArray(result)

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -164,18 +164,20 @@ class FindMixin:
     def _filter(
         self,
         query: Dict,
-        limit: Optional[Union[int, float]] = None,
+        limit: Optional[int] = None,
         only_id: bool = False,
-        **kwargs,
-    ):
+    ) -> 'DocumentArray':
         from ... import DocumentArray
         from ..queryset import QueryParser
 
         parser = QueryParser(query)
 
         result = DocumentArray()
+        limit = len(self) if (limit is None) else limit
         for d in self:
-            if (limit is None or len(result) < limit) and parser.evaluate(d):
+            if parser.evaluate(d):
                 result.append(d if not only_id else Document(id=d.id))
+                if len(result) == limit:
+                    break
 
         return result

--- a/docarray/array/queryset/__init__.py
+++ b/docarray/array/queryset/__init__.py
@@ -1,0 +1,1 @@
+from .parser import QueryParser

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -1,7 +1,11 @@
 """
+
 Originally from https://github.com/naiquevin/lookupy
+
 The library is provided as-is under the MIT License
+
 Copyright (c) 2013 Vineet Naik (naikvin@gmail.com)
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -9,8 +13,10 @@ without limitation the rights to use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and to
 permit persons to whom the Software is furnished to do so, subject to
 the following conditions:
+
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -18,6 +24,7 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 """
 
 from typing import TYPE_CHECKING

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -1,3 +1,25 @@
+"""
+Originally from https://github.com/naiquevin/lookupy
+The library is provided as-is under the MIT License
+Copyright (c) 2013 Vineet Naik (naikvin@gmail.com)
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -61,10 +61,6 @@ def lookup(key, val, doc: 'Document') -> bool:
         return iff_not_none(value, lambda y: y <= val)
     elif last == 'regex':
         return iff_not_none(value, lambda y: re.search(val, y) is not None)
-    elif last == 'filter':
-        val = guard_Q(val)
-        result = guard_list(value)
-        return len(list(filter_items(result, val))) > 0
     else:
         return value == val
 

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -123,10 +123,10 @@ class LookupNode(LookupTreeElem):
 
     """
 
-    def __init__(self):
+    def __init__(self, op: str = 'and'):
         super(LookupNode, self).__init__()
         self.children = []
-        self.op = 'and'
+        self.op = op
 
     def add_child(self, child):
         self.children.append(child)
@@ -159,6 +159,11 @@ class LookupLeaf(LookupTreeElem):
     def __init__(self, **kwargs):
         super(LookupLeaf, self).__init__()
         self.lookups = kwargs
+
+    # def add_child(self, other):
+    #     node = LookupNode()
+    #     node.add_child(self)
+    #     node.add_child(other)
 
     def evaluate(self, item):
         """Evaluates the expression represented by the object for the item

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -54,6 +54,9 @@ def lookup(key, val, doc):
     elif last == 'in':
         val = guard_iter(val)
         return value in val
+    elif last == 'nin':
+        val = guard_iter(val)
+        return not (value in val)
     elif last == 'startswith':
         val = guard_str(val)
         return iff_not_none(value, lambda y: y.startswith(val))
@@ -147,7 +150,7 @@ class LookupNode(LookupTreeElem):
         return newnode
 
     def __repr__(self):
-        return f'(op={self.op}, lookups={self.children})'
+        return f'{self.op}: [{self.children}]'
 
 
 class LookupLeaf(LookupTreeElem):

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -57,7 +57,7 @@ def lookup(key, val, doc: 'Document') -> bool:
     """
     get_key, last = dunder_partition(key)
 
-    if val.startswith('{'):
+    if isinstance(val, str) and val.startswith('{'):
         r = PLACEHOLDER_PATTERN.findall(val)
         if r and len(r) == 1:
             val = doc._get_attributes(r[0])

--- a/docarray/array/queryset/parser.py
+++ b/docarray/array/queryset/parser.py
@@ -115,5 +115,8 @@ class QueryParser:
         self.conditions = conditions
         self.lookup_groups = _parse_lookups(self.conditions)
 
-    def __call__(self, doc: 'Document'):
+    def evaluate(self, doc: 'Document'):
         return self.lookup_groups.evaluate(doc) if self.lookup_groups else True
+
+    def __call__(self, doc: 'Document'):
+        return self.evaluate(doc)

--- a/docarray/array/queryset/parser.py
+++ b/docarray/array/queryset/parser.py
@@ -1,0 +1,94 @@
+from typing import Dict, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ... import Document
+
+from .lookup import Q
+
+LOGICAL_OPERATORS = {'$and': lambda x, y: x & y, '$or': lambda x, y: x | y}
+
+COMPARISON_OPERATORS = {
+    '$lt': 'lt',
+    '$gt': 'gt',
+    '$lte': 'lte',
+    '$gte': 'gte',
+    '$eq': 'exact',
+    '$neq': 'neq',
+}
+
+MEMBERSHIP_OPERATORS = {'$in': 'in', '$nin': 'nin'}
+
+REGEX_OPERATORS = {'$regex': 'regex'}
+
+SUPPORTED_OPERATORS = {
+    **COMPARISON_OPERATORS,
+    **MEMBERSHIP_OPERATORS,
+    **REGEX_OPERATORS,
+}
+
+
+def _parse_lookups(data: Dict = {}, logic_op: Callable = LOGICAL_OPERATORS['$and']):
+    lookup_groups = None
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key in LOGICAL_OPERATORS:
+                _lookups = _parse_lookups(value, logic_op=LOGICAL_OPERATORS[key])
+                if lookup_groups is None:
+                    lookup_groups = _lookups
+                else:
+                    lookup_groups = LOGICAL_OPERATORS[key](lookup_groups, _lookups)
+            elif key.startswith('$'):
+                raise ValueError(
+                    f'The operator {key} is not supported yet, please double check the given filters!'
+                )
+            else:
+                items = list(value.items())
+                if len(items) == 0:
+                    raise ValueError(f'The query is illegal: {data}')
+
+                elif len(items) == 1:
+                    op, val = items[0]
+                    if op in LOGICAL_OPERATORS:
+                        _lookups = _parse_lookups(val, logic_op=LOGICAL_OPERATORS[op])
+                    elif op in SUPPORTED_OPERATORS:
+                        _lookups = Q(**{f'{key}__{SUPPORTED_OPERATORS[op]}': val})
+                    else:
+                        raise ValueError(
+                            f'The operator {op} is not supported yet, please double check the given filters!'
+                        )
+                    if lookup_groups is None:
+                        lookup_groups = _lookups
+                    else:
+                        lookup_groups = logic_op(lookup_groups, _lookups)
+                else:
+                    for op, val in items:
+                        _lookups = _parse_lookups({key: {op: val}})
+                        print(f'===> inner: {_lookups}')
+                        if lookup_groups is None:
+                            lookup_groups = _lookups
+                        else:
+                            # lookup_groups &= _lookups
+                            # lookup_groups = logic_op(lookup_groups, _lookups)
+                            lookup_groups.add_child(_lookups)
+    elif isinstance(data, list):
+        for d in data:
+            _lookups = _parse_lookups(d)
+            if lookup_groups is None:
+                lookup_groups = _lookups
+            else:
+                lookup_groups = logic_op(lookup_groups, _lookups)
+    else:
+        raise ValueError(f'The query is illegal: {data}')
+
+    return lookup_groups
+
+
+class QueryParser:
+    """A class to parse dict condition to lookup query."""
+
+    def __init__(self, conditions: Dict = {}):
+        self.conditions = conditions
+        self.lookup_groups = _parse_lookups(self.conditions)
+
+    def __call__(self, doc: 'Document'):
+        return self.lookup_groups.evaluate(doc) if self.lookup_groups else True

--- a/docarray/array/queryset/parser.py
+++ b/docarray/array/queryset/parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable, TYPE_CHECKING, Optional
+from typing import Dict, TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ... import Document
@@ -28,11 +28,6 @@ SUPPORTED_OPERATORS = {
 
 
 def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
-    # if isinstance(root_node, LookupLeaf):
-    #     root = LookupNode()
-    #     root.add_child(root_node)
-    #     root_node = root
-
     if isinstance(data, dict):
         for key, value in data.items():
             if isinstance(root_node, LookupLeaf):
@@ -43,10 +38,6 @@ def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
             if key in LOGICAL_OPERATORS:
                 node = LookupNode(op=key[1:])
                 node = _parse_lookups(value, root_node=node)
-                # if root_node and node:
-                #     root_node.add_child(node)
-                # elif node:
-                #     root_node = node
 
             elif key.startswith('$'):
                 raise ValueError(
@@ -69,20 +60,11 @@ def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
                             f'The operator {op} is not supported yet, please double check the given filters!'
                         )
 
-                    # if root_node and node:
-                    #     root_node.add_child(node)
-                    # elif node:
-                    #     root_node = node
-
                 else:
                     node = LookupNode()
                     for op, val in items:
                         _node = _parse_lookups({key: {op: val}})
                         node.add_child(_node)
-                        # if root_node and node:
-                        #     root_node.add_child(node)
-                        # elif node:
-                        #     root_node = node
 
             if root_node and node:
                 root_node.add_child(node)
@@ -90,14 +72,8 @@ def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
                 root_node = node
 
     elif isinstance(data, list):
-        # node = LookupNode()
         for d in data:
             node = _parse_lookups(d)
-            # node.add_child(_node)
-            # if root_node and node:
-            #     root_node.add_child(node)
-            # elif node:
-            #     root_node = node
             if root_node and node:
                 root_node.add_child(node)
             elif node:

--- a/docarray/lookup.py
+++ b/docarray/lookup.py
@@ -1,0 +1,242 @@
+import re
+from functools import partial
+
+
+## filter and lookup functions
+
+
+def filter_items(items, *args, **kwargs):
+    """Filters an iterable using lookup parameters
+
+    :param items  : iterable
+    :param args   : ``Q`` objects
+    :param kwargs : lookup parameters
+    :rtype        : lazy iterable (generator)
+
+    """
+    q1 = list(args) if args is not None else []
+    q2 = [Q(**kwargs)] if kwargs is not None else []
+    lookup_groups = q1 + q2
+    pred = lambda item: all(lg.evaluate(item) for lg in lookup_groups)
+    return (item for item in items if pred(item))
+
+
+def lookup(key, val, doc):
+    """Checks if key-val pair exists in item using various lookup types
+
+    The lookup types are derived from the `key` and then used to check
+    if the lookup holds true for the item::
+
+        >>> lookup('request__url__exact', 'http://example.com', item)
+
+    The above will return True if item['request']['url'] ==
+    'http://example.com' else False
+
+    :param key  : (str) that represents the field name to find
+    :param val  : (mixed) object to match the value in the item against
+    :param item : (dict)
+    :rtype      : (boolean) True if field-val exists else False
+
+    """
+    get_key, last = dunder_partition(key)
+
+    value = doc._get_attributes(get_key)
+    if last == 'exact':
+        return value == val
+    elif last == 'neq':
+        return value != val
+    elif last == 'contains':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: val in y)
+    elif last == 'icontains':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: val.lower() in y.lower())
+    elif last == 'in':
+        val = guard_iter(val)
+        return value in val
+    elif last == 'startswith':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: y.startswith(val))
+    elif last == 'istartswith':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: y.lower().startswith(val.lower()))
+    elif last == 'endswith':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: y.endswith(val))
+    elif last == 'iendswith':
+        val = guard_str(val)
+        return iff_not_none(value, lambda y: y.lower().endswith(val.lower()))
+    elif last == 'gt':
+        return iff_not_none(value, lambda y: y > val)
+    elif last == 'gte':
+        return iff_not_none(value, lambda y: y >= val)
+    elif last == 'lt':
+        return iff_not_none(value, lambda y: y < val)
+    elif last == 'lte':
+        return iff_not_none(value, lambda y: y <= val)
+    elif last == 'regex':
+        return iff_not_none(value, lambda y: re.search(val, y) is not None)
+    elif last == 'filter':
+        val = guard_Q(val)
+        result = guard_list(value)
+        return len(list(filter_items(result, val))) > 0
+    else:
+        return value == val
+
+
+## Classes to compose compound lookups (Q object)
+
+
+class LookupTreeElem(object):
+    """Base class for a child in the lookup expression tree"""
+
+    def __init__(self):
+        self.negate = False
+
+    def evaluate(self, item):
+        raise NotImplementedError
+
+    def __or__(self, other):
+        node = LookupNode()
+        node.op = 'or'
+        node.add_child(self)
+        node.add_child(other)
+        return node
+
+    def __and__(self, other):
+        node = LookupNode()
+        node.add_child(self)
+        node.add_child(other)
+        return node
+
+
+class LookupNode(LookupTreeElem):
+    """A node (element having children) in the lookup expression tree
+
+    Typically it's any object composed of two ``Q`` objects eg::
+
+        >>> Q(language__neq='Ruby') | Q(framework__startswith='S')
+        >>> ~Q(language__exact='PHP')
+
+    """
+
+    def __init__(self):
+        super(LookupNode, self).__init__()
+        self.children = []
+        self.op = 'and'
+
+    def add_child(self, child):
+        self.children.append(child)
+
+    def evaluate(self, item):
+        """Evaluates the expression represented by the object for the item
+
+        :param item : (dict) item
+        :rtype      : (boolean) whether lookup passed or failed
+
+        """
+        results = map(lambda x: x.evaluate(item), self.children)
+        result = any(results) if self.op == 'or' else all(results)
+        return not result if self.negate else result
+
+    def __invert__(self):
+        newnode = LookupNode()
+        for c in self.children:
+            newnode.add_child(c)
+        newnode.negate = not self.negate
+        return newnode
+
+    def __repr__(self):
+        return f'(op={self.op}, lookups={self.children})'
+
+
+class LookupLeaf(LookupTreeElem):
+    """Class for a leaf in the lookup expression tree"""
+
+    def __init__(self, **kwargs):
+        super(LookupLeaf, self).__init__()
+        self.lookups = kwargs
+
+    def evaluate(self, item):
+        """Evaluates the expression represented by the object for the item
+
+        :param item : (dict) item
+        :rtype      : (boolean) whether lookup passed or failed
+
+        """
+        result = all(lookup(k, v, item) for k, v in self.lookups.items())
+        return not result if self.negate else result
+
+    def __invert__(self):
+        newleaf = LookupLeaf(**self.lookups)
+        newleaf.negate = not self.negate
+        return newleaf
+
+    def __repr__(self):
+        return f'{self.lookups}'
+
+
+# alias LookupLeaf to Q
+Q = LookupLeaf
+
+
+## Exceptions
+
+
+class LookupyError(Exception):
+    """Base exception class for all exceptions raised by lookupy"""
+
+    pass
+
+
+## utility functions
+
+
+def dunder_partition(key):
+    """Splits a dunderkey into 2 parts
+    The first part is everything before the final double underscore
+    The second part is after the final double underscore
+        >>> dunder_partition('a__b__c')
+        >>> ('a__b', 'c')
+    :param neskey : String
+    :rtype        : 2 Tuple
+    """
+    parts = key.rsplit('__', 1)
+    return tuple(parts) if len(parts) > 1 else (parts[0], None)
+
+
+def iff(precond, val, f):
+    """If and only if the precond is True
+
+    Shortcut function for precond(val) and f(val). It is mainly used
+    to create partial functions for commonly required preconditions
+
+    :param precond : (function) represents the precondition
+    :param val     : (mixed) value to which the functions are applied
+    :param f       : (function) the actual function
+
+    """
+    return False if not precond(val) else f(val)
+
+
+iff_not_none = partial(iff, lambda x: x is not None)
+
+
+def guard_type(classinfo, val):
+    if not isinstance(val, classinfo):
+        raise LookupyError('Value not a {classinfo}'.format(classinfo=classinfo))
+    return val
+
+
+guard_str = partial(guard_type, str)
+guard_list = partial(guard_type, list)
+guard_Q = partial(guard_type, Q)
+
+
+def guard_iter(val):
+    try:
+        iter(val)
+    except TypeError:
+        raise LookupyError('Value not an iterable')
+    else:
+        return val

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -14,6 +14,11 @@ def docs():
     return docs
 
 
+def test_empty_filter(docs):
+    result = docs._filter({})
+    assert len(result) == 5
+
+
 def test_sample_filter(docs):
     result = docs._filter({'text': {'$eq': 'hello'}})
     assert len(result) == 1

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -34,6 +34,12 @@ def test_logic_filter(docs):
     assert len(result) == 2
     assert result[0].tags['x'] == 0.3 and result[1].tags['x'] == 0.8
 
+    result = docs._filter(
+        {'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}}, limit=1
+    )
+    assert len(result) == 1
+    assert result[0].tags['x'] == 0.3
+
     result = docs._filter({'tags__x': {'$gte': 0.1, '$lte': 0.5}})
     assert len(result) == 1
     assert result[0].tags['y'] == 0.6

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -15,37 +15,35 @@ def docs():
 
 
 def test_empty_filter(docs):
-    result = docs._filter({})
+    result = docs.find({})
     assert len(result) == 5
 
 
 def test_sample_filter(docs):
-    result = docs._filter({'text': {'$eq': 'hello'}})
+    result = docs.find({'text': {'$eq': 'hello'}})
     assert len(result) == 1
     assert result[0].text == 'hello'
 
-    result = docs._filter({'tags__x': {'$gte': 0.5}})
+    result = docs.find({'tags__x': {'$gte': 0.5}})
     assert len(result) == 1
     assert result[0].tags['x'] == 0.8
 
 
 def test_logic_filter(docs):
-    result = docs._filter({'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
+    result = docs.find({'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
     assert len(result) == 2
     assert result[0].tags['x'] == 0.3 and result[1].tags['x'] == 0.8
 
-    result = docs._filter(
+    result = docs.find(
         {'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}}, limit=1
     )
     assert len(result) == 1
     assert result[0].tags['x'] == 0.3
 
-    result = docs._filter({'tags__x': {'$gte': 0.1, '$lte': 0.5}})
+    result = docs.find({'tags__x': {'$gte': 0.1, '$lte': 0.5}})
     assert len(result) == 1
     assert result[0].tags['y'] == 0.6
 
-    result = docs._filter(
-        {'$and': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}}
-    )
+    result = docs.find({'$and': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
     assert len(result) == 1
     assert result[0].tags['y'] == 0.6

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -1,0 +1,40 @@
+import pytest
+
+from docarray import DocumentArray
+
+
+@pytest.fixture
+def docs():
+    docs = DocumentArray.empty(5)
+    docs[0].text = 'hello'
+    docs[1].text = 'world'
+    docs[2].tags['x'] = 0.3
+    docs[2].tags['y'] = 0.6
+    docs[3].tags['x'] = 0.8
+    return docs
+
+
+def test_sample_filter(docs):
+    result = docs._filter({'text': {'$eq': 'hello'}})
+    assert len(result) == 1
+    assert result[0].text == 'hello'
+
+    result = docs._filter({'tags__x': {'$gte': 0.5}})
+    assert len(result) == 1
+    assert result[0].tags['x'] == 0.8
+
+
+def test_logic_filter(docs):
+    result = docs._filter({'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
+    assert len(result) == 2
+    assert result[0].tags['x'] == 0.3 and result[1].tags['x'] == 0.8
+
+    result = docs._filter({'tags__x': {'$gte': 0.1, '$lte': 0.5}})
+    assert len(result) == 1
+    assert result[0].tags['y'] == 0.6
+
+    result = docs._filter(
+        {'$and': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}}
+    )
+    assert len(result) == 1
+    assert result[0].tags['y'] == 0.6

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -7,10 +7,13 @@ from docarray import DocumentArray
 def docs():
     docs = DocumentArray.empty(5)
     docs[0].text = 'hello'
+    docs[0].tags['name'] = 'hello'
     docs[1].text = 'world'
+    docs[1].tags['name'] = 'hello'
     docs[2].tags['x'] = 0.3
     docs[2].tags['y'] = 0.6
     docs[3].tags['x'] = 0.8
+
     return docs
 
 
@@ -47,3 +50,9 @@ def test_logic_filter(docs):
     result = docs.find({'$and': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
     assert len(result) == 1
     assert result[0].tags['y'] == 0.6
+
+
+def test_placehold_filter(docs):
+    result = docs.find({'text': {'$eq': '{tags__name}'}})
+    assert len(result) == 1
+    assert result[0].id == docs[0].id

--- a/tests/unit/array/test_lookup.py
+++ b/tests/unit/array/test_lookup.py
@@ -1,0 +1,38 @@
+import pytest
+from docarray import Document
+from docarray.array.queryset.lookup import lookup
+
+
+@pytest.fixture
+def doc():
+    d = Document(
+        text='test',
+        tags={'x': 0.1, 'y': 1.5, 'name': 'test', 'labels': ['a', 'b', 'test']},
+    )
+    return d
+
+
+def test_lookup_ops(doc):
+    assert lookup('text__exact', 'test', doc)
+    assert lookup('tags__x__neq', 0.2, doc)
+    assert lookup('tags__labels__contains', 'a', doc)
+    assert not lookup('tags__labels__contains', 'c', doc)
+    assert lookup('tags__name__in', ['test'], doc)
+    assert lookup('tags__x__nin', [0.2, 0.3], doc)
+    assert lookup('tags__name__startswith', 'test', doc)
+    assert not lookup('tags__name__startswith', 'Test', doc)
+    assert lookup('tags__name__istartswith', 'Test', doc)
+    assert lookup('tags__name__endswith', 'test', doc)
+    assert not lookup('tags__name__endswith', 'Test', doc)
+    assert lookup('tags__name__iendswith', 'Test', doc)
+    assert lookup('tags__x__gte', 0.1, doc)
+    assert not lookup('tags__y__gt', 1.5, doc)
+    assert lookup('tags__x__lte', 0.1, doc)
+    assert not lookup('tags__y__lt', 1.5, doc)
+
+
+def test_lookup_pl(doc):
+    assert lookup('tags__x__lt', '{tags__y}', doc)
+    assert lookup('text__exact', '{tags__name}', doc)
+    assert lookup('text__exact', '{tags__name}', doc)
+    assert lookup('text__in', '{tags__labels}', doc)

--- a/tests/unit/array/test_lookup.py
+++ b/tests/unit/array/test_lookup.py
@@ -1,6 +1,5 @@
 import pytest
 from docarray import Document
-from docarray.array.queryset.lookup import lookup
 
 
 @pytest.fixture
@@ -13,6 +12,8 @@ def doc():
 
 
 def test_lookup_ops(doc):
+    from docarray.array.queryset.lookup import lookup
+
     assert lookup('text__exact', 'test', doc)
     assert lookup('tags__x__neq', 0.2, doc)
     assert lookup('tags__labels__contains', 'a', doc)
@@ -32,7 +33,27 @@ def test_lookup_ops(doc):
 
 
 def test_lookup_pl(doc):
+    from docarray.array.queryset.lookup import lookup
+
     assert lookup('tags__x__lt', '{tags__y}', doc)
     assert lookup('text__exact', '{tags__name}', doc)
     assert lookup('text__exact', '{tags__name}', doc)
     assert lookup('text__in', '{tags__labels}', doc)
+
+
+def test_lookup_funcs():
+    from docarray.array.queryset import lookup
+
+    assert lookup.dunder_partition('a') == ('a', None)
+    assert lookup.dunder_partition('a__b__c') == ('a__b', 'c')
+
+    assert lookup.iff_not_none('a', lambda y: y == 'a')
+    assert not lookup.iff_not_none(None, lambda y: y == 'a')
+
+    lookup.guard_str('a') == 'a'
+    lookup.guard_list(['a']) == ['a']
+
+    with pytest.raises(lookup.LookupyError):
+        lookup.guard_str(0.1)
+        lookup.guard_list(0.1)
+        lookup.guard_Q(0.1)

--- a/tests/unit/array/test_queryset.py
+++ b/tests/unit/array/test_queryset.py
@@ -1,0 +1,60 @@
+from docarray.array.queryset import QueryParser
+
+
+def test_empty_query():
+    query = QueryParser()
+    assert query.lookup_groups is None
+
+
+def test_simple_query():
+    query = QueryParser({'tags__x': {'$gte': 2}})
+    assert query.lookup_groups.lookups == {'tags__x__gte': 2}
+
+    query = QueryParser({'tags__x': {'$gte': 2}, 'tags__y': {'$lt': 1}})
+    assert len(query.lookup_groups.children) == 2
+    assert query.lookup_groups.op == 'and'
+    assert query.lookup_groups.children[1].lookups == {'tags__y__lt': 1}
+
+    query = QueryParser({'tags__x': {'$gte': 0, '$lte': 54}})
+    assert len(query.lookup_groups.children) == 2
+    assert query.lookup_groups.op == 'and'
+    assert query.lookup_groups.children[0].lookups == {'tags__x__gte': 0}
+    assert query.lookup_groups.children[1].lookups == {'tags__x__lte': 54}
+
+
+def test_logic_query():
+    query = QueryParser({'$or': {'tags__x': {'$lt': 1}, 'tags__y': {'$gte': 50}}})
+    assert len(query.lookup_groups.children) == 2
+    assert query.lookup_groups.op == 'or'
+    assert query.lookup_groups.children[0].lookups == {'tags__x__lt': 1}
+    assert query.lookup_groups.children[1].lookups == {'tags__y__gte': 50}
+
+    query = QueryParser({'$or': [{'price': {'$gte': 0}}, {'price': {'$lte': 54}}]})
+    assert len(query.lookup_groups.children) == 2
+    assert query.lookup_groups.op == 'or'
+    assert query.lookup_groups.children[0].lookups == {'price__gte': 0}
+    assert query.lookup_groups.children[1].lookups == {'price__lte': 54}
+
+
+def test_complex_query():
+    conditions = {
+        '$and': {
+            'price': {'$lt': 50},
+            'rating': {'$gte': 1},
+            'year': {'$gte': 2007},
+        }
+    }
+    query = QueryParser(conditions)
+    print(conditions)
+    print(query.lookup_groups)
+
+    # conditions = {
+    #     '$and': {
+    #         'price': {'$or': [{'price': {'$gte': 0}}, {'price': {'$lte': 54}}]},
+    #         'rating': {'$gte': 1},
+    #         'year': {'$gte': 2007, '$lte': 2010},
+    #     }
+    # }
+    # query = QueryParser(conditions)
+    # print(conditions)
+    # print(query.lookup_groups)

--- a/tests/unit/array/test_queryset.py
+++ b/tests/unit/array/test_queryset.py
@@ -1,9 +1,15 @@
+import pytest
 from docarray.array.queryset import QueryParser
 
 
 def test_empty_query():
     query = QueryParser()
     assert query.lookup_groups is None
+
+
+def test_illegal_query():
+    with pytest.raises(ValueError):
+        query = QueryParser({'$may': {'brand': {'$lt': 1}, 'price': {'$gte': 50}}})
 
 
 def test_simple_query():


### PR DESCRIPTION
The example usages code:

```python
from docarray import DocumentArray

docs = DocumentArray.empty(5)
docs[0].text = 'hello'
docs[1].text = 'world'
docs[2].tags['x'] = 0.3
docs[2].tags['y'] = 0.6
docs[3].tags['x'] = 0.8

# NOTE: you can use `find` instead of `_filter`

result = docs.find({'text': {'$eq': 'hello'}})
print(DocumentArray(result).texts)

result = docs.find({'tags__x': {'$gte': 0.5}})
print(DocumentArray(result)[:, 'tags'])

result = docs.find({'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
print(DocumentArray(result)[:, 'tags'])

result = docs.find({'tags__x': {'$gte': 0.1, '$lte': 0.5}})
print(DocumentArray(result)[:, 'tags'])

result = docs.find({'$and': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
print(DocumentArray(result)[:, 'tags'])

result = docs.find({'text': {'$eq': '{tags__name}'}})
assert result[0].id == docs[0].id
```

TODO:
- [ ] documentation