### PR TITLE
feat: add none check to find

### DIFF
--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -3,6 +3,7 @@ from typing import overload, Optional, Union, Dict, List, Tuple, Callable, TYPE_
 
 import numpy as np
 
+from ...helper import check_none
 from ...math import ndarray
 from ...score import NamedScore
 
@@ -69,6 +70,9 @@ class FindMixin:
                 limit = int(limit)
 
         _limit = len(self) if limit is None else (limit + (1 if exclude_self else 0))
+
+        check_none(query, 'embedding')
+        check_none(self, 'embedding')
 
         if isinstance(query, (DocumentArray, Document)):
 

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -4,7 +4,8 @@ import sys
 import uuid
 import pathlib
 import warnings
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+
 
 ALLOWED_PROTOCOLS = {'pickle', 'protobuf', 'protobuf-array', 'pickle-array'}
 ALLOWED_COMPRESSIONS = {'lz4', 'bz2', 'lzma', 'zlib', 'gzip'}
@@ -17,6 +18,10 @@ __resources_path__ = os.path.join(
     ),
     'resources',
 )
+
+
+if TYPE_CHECKING:
+    from . import Document, DocumentArray
 
 
 def typename(obj):
@@ -388,3 +393,20 @@ def add_protocol_and_compress_to_file_path(
         file_path_extended += '.' + compress
 
     return file_path_extended
+
+
+def check_none(da: Union['Document', 'DocumentArray'], field: str):
+    """Returns TypeError if there is a None value in a field of a Document or a DocumentArray
+    """
+
+    from .document import Document
+    from .array import DocumentArray
+
+    if isinstance(da, (Document, DocumentArray)):
+        if isinstance(da, Document):
+            if type(getattr(da, field)) == type(None):
+                raise TypeError('unsupported operation, one of the embeddings is None.')
+        else:
+            for d in da:
+                if type(getattr(d, field)) == type(None):
+                    raise TypeError('unsupported operation, one of the embeddings is None.')

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -396,8 +396,7 @@ def add_protocol_and_compress_to_file_path(
 
 
 def check_none(da: Union['Document', 'DocumentArray'], field: str):
-    """Returns TypeError if there is a None value in a field of a Document or a DocumentArray
-    """
+    """Returns TypeError if there is a None value in a field of a Document or a DocumentArray"""
 
     from .document import Document
     from .array import DocumentArray
@@ -409,4 +408,6 @@ def check_none(da: Union['Document', 'DocumentArray'], field: str):
         else:
             for d in da:
                 if type(getattr(d, field)) == type(None):
-                    raise TypeError('unsupported operation, one of the embeddings is None.')
+                    raise TypeError(
+                        'unsupported operation, one of the embeddings is None.'
+                    )

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -110,12 +110,14 @@ def test_match_type_error_if_lhs_none(doc_lists):
     with pytest.raises(TypeError):
         D1.match(D2, limit=3)
 
+
 def test_match_type_error_if_rhs_none(doc_lists):
     D1, D2 = doc_lists_to_doc_arrays(doc_lists)
     D2[0].embedding = None
 
     with pytest.raises(TypeError):
         D1.match(D2, limit=3)
+
 
 @pytest.mark.parametrize(
     'limit, batch_size', [(1, None), (2, None), (None, None), (1, 1), (1, 2), (2, 1)]

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -103,6 +103,20 @@ def test_match(
     assert expected_sorted_values == sorted(expected_sorted_values)
 
 
+def test_match_type_error_if_lhs_none(doc_lists):
+    D1, D2 = doc_lists_to_doc_arrays(doc_lists)
+    D1[0].embedding = None
+
+    with pytest.raises(TypeError):
+        D1.match(D2, limit=3)
+
+def test_match_type_error_if_rhs_none(doc_lists):
+    D1, D2 = doc_lists_to_doc_arrays(doc_lists)
+    D2[0].embedding = None
+
+    with pytest.raises(TypeError):
+        D1.match(D2, limit=3)
+
 @pytest.mark.parametrize(
     'limit, batch_size', [(1, None), (2, None), (None, None), (1, 1), (1, 2), (2, 1)]
 )


### PR DESCRIPTION
This PR solves https://github.com/jina-ai/docarray/issues/157,

Note this is only done for the in memory case, since cases where storage is on disk will make this unreasonably slow,. This needs to iterate over the data and check for each doc that embedding is not None.


```python
q = Document(embedding=np.array([1,2,3]))
da2 = DocumentArray([Document(embedding=np.array([1,2,3])), 
                    Document(),
                    Document(embedding=np.array([7,8,9]))])
q.match(da2)
```
```
TypeError: unsupported operation, one of the embeddings is None.
```