### PR TITLE
fix: correct file not found error

### DIFF
--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -54,11 +54,15 @@ class BinaryIOMixin:
             file_ctx = nullcontext(file)
         elif isinstance(file, bytes):
             file_ctx = nullcontext(file)
-        elif os.path.exists(file):
-            protocol, compress = protocol_and_compress_from_file_path(
-                file, protocol, compress
-            )
-            file_ctx = open(file, 'rb')
+        elif isinstance(file, str):
+            if os.path.exists(file):
+                protocol, compress = protocol_and_compress_from_file_path(
+                    file, protocol, compress
+                )
+                file_ctx = open(file, 'rb')
+            else:
+                if not os.path.exists(file):
+                    raise FileNotFoundError(f'cannot find file {file}')
         else:
             raise ValueError(f'unsupported input {file!r}')
         if streaming:

--- a/docarray/array/mixins/io/binary.py
+++ b/docarray/array/mixins/io/binary.py
@@ -4,6 +4,7 @@ import os.path
 import os
 import pickle
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Union, BinaryIO, TYPE_CHECKING, Type, Optional, Generator
 
 from ....helper import (
@@ -24,7 +25,7 @@ class BinaryIOMixin:
     @classmethod
     def load_binary(
         cls: Type['T'],
-        file: Union[str, BinaryIO, bytes],
+        file: Union[str, BinaryIO, bytes, Path],
         protocol: str = 'pickle-array',
         compress: Optional[str] = None,
         _show_progress: bool = False,
@@ -54,17 +55,14 @@ class BinaryIOMixin:
             file_ctx = nullcontext(file)
         elif isinstance(file, bytes):
             file_ctx = nullcontext(file)
-        elif isinstance(file, str):
-            if os.path.exists(file):
-                protocol, compress = protocol_and_compress_from_file_path(
-                    file, protocol, compress
-                )
-                file_ctx = open(file, 'rb')
-            else:
-                if not os.path.exists(file):
-                    raise FileNotFoundError(f'cannot find file {file}')
+        # by checking path existence we allow file to be of type Path, LocalPath, PurePath and str
+        elif os.path.exists(file):
+            protocol, compress = protocol_and_compress_from_file_path(
+                file, protocol, compress
+            )
+            file_ctx = open(file, 'rb')
         else:
-            raise ValueError(f'unsupported input {file!r}')
+            raise FileNotFoundError(f'cannot find file {file}')
         if streaming:
             return cls._load_binary_stream(
                 file_ctx,

--- a/tests/unit/array/test_from_to_bytes.py
+++ b/tests/unit/array/test_from_to_bytes.py
@@ -93,6 +93,11 @@ def test_from_to_protobuf(target_da):
     DocumentArray.from_protobuf(target_da.to_protobuf())
 
 
+def test_non_existing_file_raises_file_not_found_error():
+    with pytest.raises(FileNotFoundError):
+        DocumentArray.load_binary('file_does_not_exists.bin')
+
+
 @pytest.mark.parametrize('target', [DocumentArray.empty(10), random_docs(10)])
 @pytest.mark.parametrize('protocol', ['jsonschema', 'protobuf'])
 @pytest.mark.parametrize('to_fn', ['dict', 'json'])


### PR DESCRIPTION
This PR raises `FileNotFoundError` when a file that is not valid is passed as input to `.load_binary`.