### PR TITLE
feat: add more comparison/logic ops

### DIFF
--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -191,6 +191,11 @@ class FindMixin:
             - `$nin` - Not included in an array
             - `$regex` - Match a specified regular expression
 
+        And the following boolean logic operators are supported:
+            - `$and` - Join query clauses with a logical AND
+            - `$or` - Join query clauses with a logical OR
+            - `$not` - Inverts the effect of a query expression
+
         :param query: the input query dictionary.
         :param limit: the maximum number of matches, when not given defaults to 20.
         :param only_id: if set, then returning documents will only contain ``id``

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -190,6 +190,8 @@ class FindMixin:
             - `$in` - Included in an array
             - `$nin` - Not included in an array
             - `$regex` - Match a specified regular expression
+            - `$size` - The array/dict field is a specified size.
+
 
         And the following boolean logic operators are supported:
             - `$and` - Join query clauses with a logical AND

--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -190,7 +190,7 @@ class FindMixin:
             - `$in` - Included in an array
             - `$nin` - Not included in an array
             - `$regex` - Match a specified regular expression
-            - `$size` - The array/dict field is a specified size.
+            - `$size` - The array/dict field is a specified size. $size does not accept ranges of values.
 
 
         And the following boolean logic operators are supported:

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -104,6 +104,8 @@ def lookup(key, val, doc: 'Document') -> bool:
         return iff_not_none(value, lambda y: y <= val)
     elif last == 'regex':
         return iff_not_none(value, lambda y: re.search(val, y) is not None)
+    elif last == 'size':
+        return iff_not_none(value, lambda y: len(y) == val)
     else:
         # return value == val
         raise ValueError(

--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -147,10 +147,11 @@ class LookupNode(LookupTreeElem):
 
     """
 
-    def __init__(self, op: str = 'and'):
+    def __init__(self, op: str = 'and', negate: bool = False):
         super(LookupNode, self).__init__()
         self.children = []
         self.op = op
+        self.negate = negate
 
     def add_child(self, child):
         self.children.append(child)

--- a/docarray/array/queryset/parser.py
+++ b/docarray/array/queryset/parser.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
 
 from .lookup import Q, LookupNode, LookupLeaf
 
-LOGICAL_OPERATORS = {'$and': lambda x, y: x & y, '$or': lambda x, y: x | y}
+LOGICAL_OPERATORS = {'$and': 'and', '$or': 'or', '$not': True}
 
 COMPARISON_OPERATORS = {
     '$lt': 'lt',
@@ -36,7 +36,10 @@ def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
                 root_node = root
 
             if key in LOGICAL_OPERATORS:
-                node = LookupNode(op=key[1:])
+                if key == '$not':
+                    node = LookupNode(negate=LOGICAL_OPERATORS[key])
+                else:
+                    node = LookupNode(op=LOGICAL_OPERATORS[key])
                 node = _parse_lookups(value, root_node=node)
 
             elif key.startswith('$'):
@@ -51,7 +54,10 @@ def _parse_lookups(data: Dict = {}, root_node: Optional[LookupNode] = None):
                 elif len(items) == 1:
                     op, val = items[0]
                     if op in LOGICAL_OPERATORS:
-                        node = LookupNode(op=op[1:])
+                        if op == '$not':
+                            node = LookupNode(negate=LOGICAL_OPERATORS[op])
+                        else:
+                            node = LookupNode(op=LOGICAL_OPERATORS[op])
                         node = _parse_lookups(val, root_node=node)
                     elif op in SUPPORTED_OPERATORS:
                         node = Q(**{f'{key}__{SUPPORTED_OPERATORS[op]}': val})

--- a/docarray/array/queryset/parser.py
+++ b/docarray/array/queryset/parser.py
@@ -16,14 +16,17 @@ COMPARISON_OPERATORS = {
     '$neq': 'neq',
 }
 
-MEMBERSHIP_OPERATORS = {'$in': 'in', '$nin': 'nin'}
-
 REGEX_OPERATORS = {'$regex': 'regex'}
+
+ARRAY_OPERATORS = {'$size': 'size'}
+
+MEMBERSHIP_OPERATORS = {'$in': 'in', '$nin': 'nin'}
 
 SUPPORTED_OPERATORS = {
     **COMPARISON_OPERATORS,
-    **MEMBERSHIP_OPERATORS,
+    **ARRAY_OPERATORS,
     **REGEX_OPERATORS,
+    **MEMBERSHIP_OPERATORS,
 }
 
 

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -59,6 +59,13 @@ def test_logic_filter(docs):
     assert len(result) == 1
     assert result[0].tags['y'] == 0.6
 
+    result = docs.find({'$not': {'tags__x': {'$gte': 0.5}}})
+    assert len(result) == 4
+    assert 'x' not in result[0].tags or result[0].tags['x'] < 0.5
+
+    result = docs.find({'$not': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})
+    assert len(result) == 4
+
 
 def test_placehold_filter(docs):
     result = docs.find({'text': {'$eq': '{tags__name}'}})

--- a/tests/unit/array/mixins/test_filter.py
+++ b/tests/unit/array/mixins/test_filter.py
@@ -39,6 +39,9 @@ def test_simple_filter(docs):
     assert len(result) == 1
     assert result[0].id == docs[0].id
 
+    result = docs.find({'tags': {'$size': 2}})
+    assert result[0].id == docs[2].id
+
 
 def test_logic_filter(docs):
     result = docs.find({'$or': {'tags__x': {'$gte': 0.1}, 'tags__y': {'$gte': 0.5}}})

--- a/tests/unit/array/test_lookup.py
+++ b/tests/unit/array/test_lookup.py
@@ -34,6 +34,9 @@ def test_lookup_ops(doc):
     assert lookup('text__regex', '^test', doc)
     assert not lookup('text__regex', '^est', doc)
 
+    assert lookup('tags__size', 4, doc)
+    assert lookup('tags__labels__size', 3, doc)
+
 
 def test_lookup_pl(doc):
     from docarray.array.queryset.lookup import lookup

--- a/tests/unit/array/test_queryset.py
+++ b/tests/unit/array/test_queryset.py
@@ -27,6 +27,9 @@ def test_simple_query():
     assert query.lookup_groups.children[0].lookups == {'tags__x__gte': 0}
     assert query.lookup_groups.children[1].lookups == {'tags__x__lte': 54}
 
+    query = QueryParser({'tags': {'$size': 1}})
+    assert query.lookup_groups.lookups == {'tags__size': 1}
+
 
 def test_logic_query():
     query = QueryParser({'$or': {'tags__x': {'$lt': 1}, 'tags__y': {'$gte': 50}}})

--- a/tests/unit/array/test_queryset.py
+++ b/tests/unit/array/test_queryset.py
@@ -36,10 +36,19 @@ def test_logic_query():
     assert query.lookup_groups.children[1].lookups == {'tags__y__gte': 50}
 
     query = QueryParser({'$or': [{'price': {'$gte': 0}}, {'price': {'$lte': 54}}]})
+    assert not query.lookup_groups.negate
     assert len(query.lookup_groups.children) == 2
     assert query.lookup_groups.op == 'or'
     assert query.lookup_groups.children[0].lookups == {'price__gte': 0}
     assert query.lookup_groups.children[1].lookups == {'price__lte': 54}
+
+    query = QueryParser({'$not': [{'price': {'$gte': 0}}, {'price': {'$lte': 54}}]})
+    assert query.lookup_groups.negate
+    assert query.lookup_groups.op == 'and'
+    assert len(query.lookup_groups.children) == 2
+
+    query = QueryParser({'$not': {'price': {'$gte': 0}}})
+    assert query.lookup_groups.negate
 
 
 def test_complex_query():


### PR DESCRIPTION
- `$not` logic ops, e.g., 

    `docs.find({'$not': {'tags__x': {'$gte': 0.5}}})`

- `$size` op

    `docs.find({'tags': {'$size': 2}})`