### PR TITLE
perf: optimize Document init

### DIFF
--- a/docarray/base.py
+++ b/docarray/base.py
@@ -50,11 +50,9 @@ class BaseDCType:
                 for k in _unresolved:
                     kwargs.pop(k)
 
-            self._data = self._data_class(self)
-
-            for f in _fields:
-                if f in kwargs:
-                    setattr(self._data, f, kwargs[f])
+            self._data = self._data_class(
+                self, **{f: kwargs[f] for f in _fields if f in kwargs}
+            )
 
             if _unknown_kwargs and unknown_fields_handler == 'catch':
                 getattr(self, self._unresolved_fields_dest).update(_unknown_kwargs)

--- a/docarray/base.py
+++ b/docarray/base.py
@@ -35,27 +35,36 @@ class BaseDCType:
             kwargs.update(_obj)
 
         if kwargs:
-            if field_resolver:
-                kwargs = {field_resolver.get(k, k): v for k, v in kwargs.items()}
-
-            _fields = _get_fields(self._data_class)
-            _unknown_kwargs = None
-            _unresolved = set(kwargs.keys()).difference(_fields)
-
-            if _unresolved:
+            try:
+                self._data = self._data_class(self, **kwargs)
+            except TypeError as ex:
                 if unknown_fields_handler == 'raise':
-                    raise AttributeError(f'unknown attributes: {_unresolved}')
+                    raise AttributeError(f'unknown attributes') from ex
+                elif unknown_fields_handler == 'catch':
+                    if field_resolver:
+                        kwargs = {
+                            field_resolver.get(k, k): v for k, v in kwargs.items()
+                        }
 
-                _unknown_kwargs = {k: kwargs[k] for k in _unresolved}
-                for k in _unresolved:
-                    kwargs.pop(k)
+                    _fields = _get_fields(self._data_class)
+                    _unknown_kwargs = None
+                    _unresolved = set(kwargs.keys()).difference(_fields)
 
-            self._data = self._data_class(
-                self, **{f: kwargs[f] for f in _fields if f in kwargs}
-            )
+                    if _unresolved:
+                        _unknown_kwargs = {k: kwargs[k] for k in _unresolved}
+                        for k in _unresolved:
+                            kwargs.pop(k)
 
-            if _unknown_kwargs and unknown_fields_handler == 'catch':
-                getattr(self, self._unresolved_fields_dest).update(_unknown_kwargs)
+                    self._data = self._data_class(self, **kwargs)
+
+                    if _unknown_kwargs:
+                        getattr(self, self._unresolved_fields_dest).update(
+                            _unknown_kwargs
+                        )
+
+            for k in self._post_init_fields:
+                if k in kwargs:
+                    setattr(self, k, kwargs[k])
 
         if not _obj and not kwargs and self._data is None:
             self._data = self._data_class(self)

--- a/docarray/base.py
+++ b/docarray/base.py
@@ -40,7 +40,7 @@ class BaseDCType:
             except TypeError as ex:
                 if unknown_fields_handler == 'raise':
                     raise AttributeError(f'unknown attributes') from ex
-                elif unknown_fields_handler == 'catch':
+                else:
                     if field_resolver:
                         kwargs = {
                             field_resolver.get(k, k): v for k, v in kwargs.items()
@@ -57,7 +57,7 @@ class BaseDCType:
 
                     self._data = self._data_class(self, **kwargs)
 
-                    if _unknown_kwargs:
+                    if _unknown_kwargs and unknown_fields_handler == 'catch':
                         getattr(self, self._unresolved_fields_dest).update(
                             _unknown_kwargs
                         )

--- a/docarray/document/__init__.py
+++ b/docarray/document/__init__.py
@@ -11,6 +11,16 @@ if TYPE_CHECKING:
 class Document(AllMixins, BaseDCType):
     _data_class = DocumentData
     _unresolved_fields_dest = 'tags'
+    _post_init_fields = (
+        'text',
+        'blob',
+        'tensor',
+        'content',
+        'uri',
+        'mime_type',
+        'chunks',
+        'matches',
+    )
 
     @overload
     def __init__(self):

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -1,5 +1,5 @@
 import mimetypes
-import uuid
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -35,7 +35,7 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = field(default_factory=lambda: uuid.uuid1().hex)
+    id: str = field(default_factory=lambda: os.urandom(16).hex())
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -35,7 +35,7 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = ''
+    id: str = field(default_factory=lambda: uuid.uuid1().hex)
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None

--- a/docarray/document/mixins/property.py
+++ b/docarray/document/mixins/property.py
@@ -40,13 +40,12 @@ class PropertyMixin(_PropertyMixin):
 
     @content.setter
     def content(self, value: 'DocumentContentType'):
-        if value is None:
-            self._clear_content()
-        elif isinstance(value, bytes):
+        self._clear_content()
+        if isinstance(value, bytes):
             self._data.blob = value
         elif isinstance(value, str):
             self._data.text = value
-        else:
+        elif value is not None:
             self._data.tensor = value
 
     @_PropertyMixin.uri.setter

--- a/docarray/document/mixins/property.py
+++ b/docarray/document/mixins/property.py
@@ -51,15 +51,16 @@ class PropertyMixin(_PropertyMixin):
 
     @_PropertyMixin.uri.setter
     def uri(self, value: str):
-        mime_type = mimetypes.guess_type(value)[0]
+        if value:
+            mime_type = mimetypes.guess_type(value)[0]
 
-        if mime_type:
-            self._data.mime_type = mime_type
+            if mime_type:
+                self._data.mime_type = mime_type
         self._data.uri = value
 
     @_PropertyMixin.mime_type.setter
     def mime_type(self, value: str):
-        if value not in _all_mime_types:
+        if value and value not in _all_mime_types:
             # given but not recognizable, do best guess
             r = mimetypes.guess_type(f'*.{value}')[0]
             value = r or value

--- a/docarray/score/__init__.py
+++ b/docarray/score/__init__.py
@@ -5,3 +5,4 @@ from ..base import BaseDCType
 
 class NamedScore(AllMixins, BaseDCType):
     _data_class = NamedScoreData
+    _post_init_fields = ()


### PR DESCRIPTION
Init 300K classes, Py37, MacM1

Before:
```
init empty Python class ...	0.028s
init Doc no content ...	2.251s
init Doc with content ...	3.091s
init Doc with content and embedding ...	3.463s
```

This PR
```
init empty Python class ...	0.029s
init Doc no content ...	1.025s
init Doc with content ...	1.268s
init Doc with content and embedding ...	1.361s
```

---

```python
from docarray import Document
from toytime import TimeContext


class A:
    ...


with TimeContext('init empty Python class'):
    for _ in range(300_000):
        A()

with TimeContext('init no Doc content'):
    for _ in range(300_000):
        Document()

with TimeContext('init with Doc content'):
    for _ in range(300_000):
        Document(content='hello')

with TimeContext('init with Doc content and embedding'):
    for _ in range(300_000):
        Document(content='hello', embedding=[1, 2, 3], parent_id='213')

```
