### PR TITLE
perf: speedup id construction time

### DIFF
--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -1,5 +1,5 @@
 import mimetypes
-import os
+import random
 from collections import defaultdict
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -35,7 +35,9 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = field(default_factory=lambda: os.urandom(16).hex())
+    id: str = field(
+        default_factory=lambda: random.getrandbits(128).to_bytes(16, 'big').hex()
+    )
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -35,9 +35,7 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = field(
-        default_factory=lambda: random.getrandbits(128).to_bytes(16, 'big').hex()
-    )
+    id: str = field(default_factory=random.getrandbits(128).to_bytes(16, 'big').hex)
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -35,7 +35,9 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = field(default_factory=random.getrandbits(128).to_bytes(16, 'big').hex)
+    id: str = field(
+        default_factory=lambda: random.getrandbits(128).to_bytes(16, 'big').hex()
+    )
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None


### PR DESCRIPTION
In this PR
```python
In [4]: %timeit da = DocumentArray.empty(100_000)
396 ms ± 3.59 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

In main ( with the last version of `os.urandom(16).hex()`)
```python
In [3]: %timeit da = DocumentArray.empty(100_000)
603 ms ± 7.34 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Note that I don't simply do `hex(random.getrandbits(128))` because this does not warranty that the hex value will be 32 hex long, which would not make it parsable as a UUID. 

This has a very high chance of failing
```python
uuids = [uuid.UUID(hex(random.getrandbits(128))) for i in range(100_000)]
```
whereas this will allways work
```python
uuids = [uuid.UUID(random.getrandbits(128).to_bytes(16, 'big').hex()) for i in range(100_000)]
```

Note: in future versions, when we use Python 3.9 , we can use  `random.randbytes` which would allow us to generate this simply with `random.randbytes(16)`.