### PR TITLE
refactor: simplify da type checking

### DIFF
--- a/docarray/array/chunk.py
+++ b/docarray/array/chunk.py
@@ -1,7 +1,6 @@
 from typing import (
     TYPE_CHECKING,
     Iterable,
-    Iterator,
 )
 
 from .memory import DocumentArrayInMemory
@@ -28,7 +27,7 @@ class ChunkArray(DocumentArrayInMemory):
         """
         self._ref_doc = reference_doc
         super().__init__(docs)
-        if isinstance(docs, (Iterable, Iterator)) and self._ref_doc is not None:
+        if isinstance(docs, Iterable) and self._ref_doc is not None:
             for d in docs:
                 d.parent_id = self._ref_doc.id
                 d.granularity = self._ref_doc.granularity + 1

--- a/docarray/array/chunk.py
+++ b/docarray/array/chunk.py
@@ -1,12 +1,9 @@
-import itertools
 from typing import (
     TYPE_CHECKING,
-    Generator,
+    Iterable,
     Iterator,
-    Sequence,
 )
 
-from .document import DocumentArray
 from .memory import DocumentArrayInMemory
 
 if TYPE_CHECKING:
@@ -31,12 +28,7 @@ class ChunkArray(DocumentArrayInMemory):
         """
         self._ref_doc = reference_doc
         super().__init__(docs)
-        if (
-            isinstance(
-                docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-            )
-            and self._ref_doc is not None
-        ):
+        if isinstance(docs, (Iterable, Iterator)) and self._ref_doc is not None:
             for d in docs:
                 d.parent_id = self._ref_doc.id
                 d.granularity = self._ref_doc.granularity + 1

--- a/docarray/array/match.py
+++ b/docarray/array/match.py
@@ -1,12 +1,9 @@
-import itertools
 from typing import (
     TYPE_CHECKING,
-    Generator,
+    Iterable,
     Iterator,
-    Sequence,
 )
 
-from .document import DocumentArray
 from .memory import DocumentArrayInMemory
 
 if TYPE_CHECKING:
@@ -25,12 +22,7 @@ class MatchArray(DocumentArrayInMemory):
     def __init__(self, docs, reference_doc: 'Document'):
         self._ref_doc = reference_doc
         super().__init__(docs)
-        if (
-            isinstance(
-                docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-            )
-            and self._ref_doc is not None
-        ):
+        if isinstance(docs, (Iterable, Iterator)) and self._ref_doc is not None:
             for d in docs:
                 d.adjacency = self._ref_doc.adjacency + 1
 

--- a/docarray/array/match.py
+++ b/docarray/array/match.py
@@ -1,7 +1,6 @@
 from typing import (
     TYPE_CHECKING,
     Iterable,
-    Iterator,
 )
 
 from .memory import DocumentArrayInMemory
@@ -22,7 +21,7 @@ class MatchArray(DocumentArrayInMemory):
     def __init__(self, docs, reference_doc: 'Document'):
         self._ref_doc = reference_doc
         super().__init__(docs)
-        if isinstance(docs, (Iterable, Iterator)) and self._ref_doc is not None:
+        if isinstance(docs, Iterable) and self._ref_doc is not None:
             for d in docs:
                 d.adjacency = self._ref_doc.adjacency + 1
 

--- a/docarray/array/storage/annlite/backend.py
+++ b/docarray/array/storage/annlite/backend.py
@@ -1,4 +1,3 @@
-import itertools
 import numpy as np
 from dataclasses import dataclass, asdict, field
 from typing import (
@@ -6,8 +5,7 @@ from typing import (
     Dict,
     Optional,
     TYPE_CHECKING,
-    Sequence,
-    Generator,
+    Iterable,
     Iterator,
 )
 
@@ -27,7 +25,7 @@ class AnnliteConfig:
 
 
 class BackendMixin(BaseBackendMixin):
-    """Provide necessary functions to enable this storage backend. """
+    """Provide necessary functions to enable this storage backend."""
 
     def _map_embedding(self, embedding: 'ArrayType') -> 'ArrayType':
         if embedding is None:
@@ -77,9 +75,7 @@ class BackendMixin(BaseBackendMixin):
 
         self.clear()
 
-        if isinstance(
-            _docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-        ):
+        if isinstance(_docs, (Iterable, Iterator)):
             self.extend(_docs)
         elif isinstance(_docs, Document):
             self.append(_docs)

--- a/docarray/array/storage/annlite/backend.py
+++ b/docarray/array/storage/annlite/backend.py
@@ -6,7 +6,6 @@ from typing import (
     Optional,
     TYPE_CHECKING,
     Iterable,
-    Iterator,
 )
 
 from ..base.backend import BaseBackendMixin
@@ -75,7 +74,7 @@ class BackendMixin(BaseBackendMixin):
 
         self.clear()
 
-        if isinstance(_docs, (Iterable, Iterator)):
+        if isinstance(_docs, Iterable):
             self.extend(_docs)
         elif isinstance(_docs, Document):
             self.append(_docs)

--- a/docarray/array/storage/memory/backend.py
+++ b/docarray/array/storage/memory/backend.py
@@ -1,7 +1,5 @@
-import itertools
 from typing import (
     Iterator,
-    Iterable,
     Optional,
     TYPE_CHECKING,
 )
@@ -34,7 +32,7 @@ class BackendMixin(BaseBackendMixin):
             return
         elif isinstance(
             _docs,
-            (Iterable, Iterator),
+            Iterator,
         ):
             if copy:
                 for doc in _docs:

--- a/docarray/array/storage/memory/backend.py
+++ b/docarray/array/storage/memory/backend.py
@@ -1,9 +1,7 @@
 import itertools
 from typing import (
-    Generator,
     Iterator,
-    Dict,
-    Sequence,
+    Iterable,
     Optional,
     TYPE_CHECKING,
 )
@@ -36,7 +34,7 @@ class BackendMixin(BaseBackendMixin):
             return
         elif isinstance(
             _docs,
-            (DocumentArray, Sequence, Generator, Iterator, itertools.chain),
+            (Iterable, Iterator),
         ):
             if copy:
                 for doc in _docs:

--- a/docarray/array/storage/memory/backend.py
+++ b/docarray/array/storage/memory/backend.py
@@ -1,7 +1,7 @@
 from typing import (
-    Iterator,
     Optional,
     TYPE_CHECKING,
+    Iterable,
 )
 
 from ..base.backend import BaseBackendMixin
@@ -32,7 +32,7 @@ class BackendMixin(BaseBackendMixin):
             return
         elif isinstance(
             _docs,
-            Iterator,
+            Iterable,
         ):
             if copy:
                 for doc in _docs:

--- a/docarray/array/storage/memory/getsetdel.py
+++ b/docarray/array/storage/memory/getsetdel.py
@@ -1,7 +1,6 @@
 from typing import (
     Sequence,
     Iterable,
-    Any,
 )
 
 from ..base.getsetdel import BaseGetSetDelMixin

--- a/docarray/array/storage/qdrant/backend.py
+++ b/docarray/array/storage/qdrant/backend.py
@@ -1,4 +1,3 @@
-import itertools
 import uuid
 from dataclasses import dataclass, field
 from typing import (
@@ -6,8 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
     Dict,
-    Sequence,
-    Generator,
+    Iterable,
     Iterator,
     List,
 )
@@ -105,9 +103,7 @@ class BackendMixin(BaseBackendMixin):
         # is provided, :class:`DocumentArraySqlite` will clear the existing
         # table and load the given `docs`
         self.clear()
-        if isinstance(
-            docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-        ):
+        if isinstance(docs, (Iterable, Iterator)):
             self.extend(docs)
         elif isinstance(docs, Document):
             self.append(docs)

--- a/docarray/array/storage/qdrant/backend.py
+++ b/docarray/array/storage/qdrant/backend.py
@@ -6,7 +6,6 @@ from typing import (
     Union,
     Dict,
     Iterable,
-    Iterator,
     List,
 )
 
@@ -103,7 +102,7 @@ class BackendMixin(BaseBackendMixin):
         # is provided, :class:`DocumentArraySqlite` will clear the existing
         # table and load the given `docs`
         self.clear()
-        if isinstance(docs, (Iterable, Iterator)):
+        if isinstance(docs, Iterable):
             self.extend(docs)
         elif isinstance(docs, Document):
             self.append(docs)

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -1,13 +1,11 @@
-import itertools
 import sqlite3
 import warnings
 from dataclasses import dataclass, field
 from tempfile import NamedTemporaryFile
 from typing import (
-    Generator,
+    Iterable,
     Iterator,
     Dict,
-    Sequence,
     Optional,
     TYPE_CHECKING,
     Union,
@@ -116,9 +114,7 @@ class BackendMixin(BaseBackendMixin):
 
         if _docs is None:
             return
-        elif isinstance(
-            _docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-        ):
+        elif isinstance(_docs, (Iterable, Iterator)):
             self.clear()
             self.extend(_docs)
         else:

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from tempfile import NamedTemporaryFile
 from typing import (
     Iterable,
-    Iterator,
     Dict,
     Optional,
     TYPE_CHECKING,
@@ -114,7 +113,7 @@ class BackendMixin(BaseBackendMixin):
 
         if _docs is None:
             return
-        elif isinstance(_docs, (Iterable, Iterator)):
+        elif isinstance(_docs, Iterable):
             self.clear()
             self.extend(_docs)
         else:

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -2,7 +2,6 @@ import uuid
 from dataclasses import dataclass, field
 from typing import (
     Iterable,
-    Iterator,
     Dict,
     Optional,
     TYPE_CHECKING,
@@ -13,7 +12,6 @@ from typing import (
 
 import numpy as np
 import weaviate
-from weaviate.auth import AuthCredentials
 
 from ..base.backend import BaseBackendMixin
 from .... import Document
@@ -88,7 +86,7 @@ class BackendMixin(BaseBackendMixin):
         # table and load the given `docs`
         if _docs is None:
             return
-        elif isinstance(_docs, (Iterable, Iterator)):
+        elif isinstance(_docs, Iterable):
             self.clear()
             self.extend(_docs)
         else:

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -1,11 +1,9 @@
-import itertools
 import uuid
 from dataclasses import dataclass, field
 from typing import (
-    Generator,
+    Iterable,
     Iterator,
     Dict,
-    Sequence,
     Optional,
     TYPE_CHECKING,
     Union,
@@ -90,9 +88,7 @@ class BackendMixin(BaseBackendMixin):
         # table and load the given `docs`
         if _docs is None:
             return
-        elif isinstance(
-            _docs, (DocumentArray, Sequence, Generator, Iterator, itertools.chain)
-        ):
+        elif isinstance(_docs, (Iterable, Iterator)):
             self.clear()
             self.extend(_docs)
         else:

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -65,7 +65,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
             self._client.data_object.delete(wid)
 
     def _clear_storage(self):
-        """ Concrete implementation of base class' ``_clear_storage``"""
+        """Concrete implementation of base class' ``_clear_storage``"""
         if self._class_name:
             self._client.schema.delete_class(self._class_name)
             self._client.schema.delete_class(self._meta_name)


### PR DESCRIPTION
`DocumentArray` is `MutableSequence` -> `Sequence` -> `Iterable`.

`iter(da)` is `Generator` -> `Iterator` -> `Iterable`.

`chain(da1, da2)` is both `Iterable` and `Iterator`.

Maybe we only need to check 1 type

```python
from docarray import DocumentArray, Document

from typing import Generator, Iterator, Sequence, Iterable

da = DocumentArray([Document(), Document(), Document()])

print(isinstance(da, DocumentArray))
print(isinstance(da, Sequence))
print(isinstance(da, Iterable))


my_iter = iter(da)

print(isinstance(my_iter, Iterator))
print(isinstance(my_iter, Generator))

from itertools import chain

da1 = DocumentArray([Document()])
da2 = DocumentArray([Document(), Document()])

# chaining da1 and da2 numbers
da = chain(da1, da2)
print(isinstance(da, Iterator))
print(isinstance(da, Iterable))
print(type(da))
```