### PR TITLE
fix: fix PIL dependency

### DIFF
--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -1,5 +1,3 @@
-from rich import box
-
 from ...helper import deprecate_by
 
 
@@ -11,8 +9,10 @@ class PlotMixin:
         self.summary()
 
     def __rich_console__(self, console, options):
+
         yield f":page_facing_up: [b]Document[/b]: [cyan]{self.id}[cyan]"
         from rich.table import Table
+        from rich import box
 
         my_table = Table('Attribute', 'Value', width=80, box=box.ROUNDED)
         for f in self.non_empty_fields:

--- a/docarray/types/serializers.py
+++ b/docarray/types/serializers.py
@@ -2,13 +2,14 @@ import json
 from typing import TYPE_CHECKING
 
 import numpy as np
-from PIL.Image import Image
 
 if TYPE_CHECKING:
     from docarray import Document
 
 
 def image_serializer(inp, attribute_name, doc: 'Document'):
+    from PIL.Image import Image
+
     if isinstance(inp, str):
         doc.uri = inp
         doc._metadata['image_type'] = 'uri'


### PR DESCRIPTION
Currently, installing docarray and using it fails because PIL is not installed with the default tag.