### PR TITLE
test(image): add unit tests for _to_image_tensor

### DIFF
--- a/tests/unit/document/test_image.py
+++ b/tests/unit/document/test_image.py
@@ -1,0 +1,42 @@
+import os
+
+import numpy as np
+import pytest
+from PIL import Image
+import io
+
+from docarray.document.mixins.image import _to_image_tensor
+
+
+@pytest.mark.parametrize(
+    "width, height, output_shape",
+    [
+        (None, None, (50, 10, 3)),
+        (8, None, (50, 8, 3)),
+        (None, 30, (30, 10, 3)),
+        (30, 8, (8, 30, 3)),
+    ],
+)
+def test_to_image_tensor_pil(rgb_image_path, width, height, output_shape):
+    tensor = _to_image_tensor(rgb_image_path, width, height)
+
+    assert tensor.shape == output_shape
+    assert isinstance(tensor, np.ndarray)
+
+
+def test_to_image_tensor_blob(rgb_image_path):
+    with open(rgb_image_path, "rb") as f:
+        blob = io.BytesIO(f.read())
+
+    tensor = _to_image_tensor(blob, None, None)
+
+    assert tensor.shape == (50, 10, 3)
+    assert isinstance(tensor, np.ndarray)
+
+
+@pytest.fixture
+def rgb_image_path(tmpdir):
+    img_path = os.path.join(tmpdir, "image.png")
+    RGB_COLOR_10X50_155_0_0 = Image.new("RGB", size=(10, 50), color=(0, 0, 0))
+    RGB_COLOR_10X50_155_0_0.save(img_path)
+    return img_path

--- a/tests/unit/document/test_image.py
+++ b/tests/unit/document/test_image.py
@@ -9,7 +9,7 @@ from docarray.document.mixins.image import _to_image_tensor
 
 
 @pytest.mark.parametrize(
-    "width, height, output_shape",
+    'width, height, output_shape',
     [
         (None, None, (50, 10, 3)),
         (8, None, (50, 8, 3)),
@@ -25,7 +25,7 @@ def test_to_image_tensor_pil(rgb_image_path, width, height, output_shape):
 
 
 def test_to_image_tensor_blob(rgb_image_path):
-    with open(rgb_image_path, "rb") as f:
+    with open(rgb_image_path, 'rb') as f:
         blob = io.BytesIO(f.read())
 
     tensor = _to_image_tensor(blob, None, None)
@@ -36,7 +36,7 @@ def test_to_image_tensor_blob(rgb_image_path):
 
 @pytest.fixture
 def rgb_image_path(tmpdir):
-    img_path = os.path.join(tmpdir, "image.png")
-    RGB_COLOR_10X50_155_0_0 = Image.new("RGB", size=(10, 50), color=(0, 0, 0))
+    img_path = os.path.join(tmpdir, 'image.png')
+    RGB_COLOR_10X50_155_0_0 = Image.new('RGB', size=(10, 50), color=(0, 0, 0))
     RGB_COLOR_10X50_155_0_0.save(img_path)
     return img_path

--- a/tests/unit/document/test_image.py
+++ b/tests/unit/document/test_image.py
@@ -37,6 +37,6 @@ def test_to_image_tensor_blob(rgb_image_path):
 @pytest.fixture
 def rgb_image_path(tmpdir):
     img_path = os.path.join(tmpdir, 'image.png')
-    RGB_COLOR_10X50_155_0_0 = Image.new('RGB', size=(10, 50), color=(0, 0, 0))
-    RGB_COLOR_10X50_155_0_0.save(img_path)
+    image = Image.new('RGB', size=(10, 50), color=(0, 0, 0))
+    image.save(img_path)
     return img_path


### PR DESCRIPTION
This PR is adding two unit tests for the function `_to_image_tensor` in `docarray/document/mixins/image.py`.

--- 
**Note**: I could not find a way to cover lines 340-341: https://github.com/jina-ai/docarray/blob/73f2aef9d3145f4d29982681fc8632230c37fdf4/docarray/document/mixins/image.py#L338-L341

By looking at the internals of `PIL.Image.convert`, it seems like there is no way to read the image correctly at
https://github.com/jina-ai/docarray/blob/73f2aef9d3145f4d29982681fc8632230c37fdf4/docarray/document/mixins/image.py#L333

and then make it fail during the conversion to `RGB`. Could it be a leftover/patch for something weird that happened in the past? If not, how can this be meaningfully tested?