### PR TITLE
feat: added support for all Weaviate HNSW configuration parameters

### DIFF
--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -37,13 +37,13 @@ class WeaviateConfig:
     ef_construction: Optional[int] = None
     timeout_config: Optional[Tuple[int, int]] = None
     max_connections: Optional[int] = None
-    dynamic_ef_min: Optional[int] = field(default=100)
-    dynamic_ef_max: Optional[int] = field(default=500)
-    dynamic_ef_factor: Optional[int] = field(default=8)
-    vector_cache_max_objects: Optional[Union[int, str]] = field(default="2M")
-    flat_search_cutoff: Optional[int] = field(default=40000)
+    dynamic_ef_min: Optional[int] = None
+    dynamic_ef_max: Optional[int] = None
+    dynamic_ef_factor: Optional[int] = None
+    vector_cache_max_objects: Optional[Union[int, str]] = None
+    flat_search_cutoff: Optional[int] = None
     cleanup_interval_seconds: Optional[int] = None
-    skip: Optional[bool] = False
+    skip: Optional[bool] = None
 
 
 class BackendMixin(BaseBackendMixin):

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -32,6 +32,7 @@ class WeaviateConfig:
     protocol: Optional[str] = field(default='http')
     name: Optional[str] = None
     serialize_config: Dict = field(default_factory=dict)
+    n_dim: Optional[int] = None  # deprecated, not used anymore since weaviate 1.10
     # vectorIndexConfig parameters
     ef: Optional[int] = None
     ef_construction: Optional[int] = None

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -32,11 +32,18 @@ class WeaviateConfig:
     protocol: Optional[str] = field(default='http')
     name: Optional[str] = None
     serialize_config: Dict = field(default_factory=dict)
-    n_dim: Optional[int] = None  # deprecated, not used anymore since weaviate 1.10
+    # vectorIndexConfig parameters
     ef: Optional[int] = None
     ef_construction: Optional[int] = None
     timeout_config: Optional[Tuple[int, int]] = None
     max_connections: Optional[int] = None
+    dynamic_ef_min: Optional[int] = field(default=100)
+    dynamic_ef_max: Optional[int] = field(default=500)
+    dynamic_ef_factor: Optional[int] = field(default=8)
+    vector_cache_max_objects: Optional[Union[int, str]] = field(default="2M")
+    flat_search_cutoff: Optional[int] = field(default=40000)
+    cleanup_interval_seconds: Optional[int] = None
+    skip: Optional[bool] = False
 
 
 class BackendMixin(BaseBackendMixin):
@@ -120,6 +127,13 @@ class BackendMixin(BaseBackendMixin):
             'ef': self._config.ef,
             'efConstruction': self._config.ef_construction,
             'maxConnections': self._config.max_connections,
+            'dynamicEfMin': self._config.dynamic_ef_min,
+            'dynamicEfMax': self._config.dynamic_ef_max,
+            'dynamicEfFactor': self._config.dynamic_ef_factor,
+            'vectorCacheMaxObjects': self._config.vector_cache_max_objects,
+            'flatSearchCutoff': self._config.flat_search_cutoff,
+            'cleanupIntervalSeconds': self._config.cleanup_interval_seconds,
+            'skip': self._config.skip
         }
 
         return {


### PR DESCRIPTION
The biggest reason for this PR is to enable DocArray to import large datasets (2M+ objects) to Weaviate backend (see https://weaviate.io/developers/weaviate/current/architecture/resources.html#imports-slowed-down-after-crossing-2m-objects---what-can-i-do). The current implementation does not allow passing relevant configuration parameters for Weaviate.

This PR adds support for all currently listed Weaviate HNSW parameters based on the documentation available here: https://weaviate.io/developers/weaviate/current/vector-index-plugins/hnsw.html#how-to-use-hnsw-and-parameters

