### PR TITLE
perf[sqlite]: batch update on sqlite extend

### DIFF
--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -43,9 +43,6 @@ class BackendMixin(BaseBackendMixin):
     def _sql(self, *args, **kwargs) -> 'sqlite3.Cursor':
         return self._cursor.execute(*args, **kwargs)
 
-    def _sql_many(self, request, values) -> 'sqlite3.Cursor':
-        return self._cursor.executemany(request, values)
-
     def _commit(self):
         self._connection.commit()
 

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -43,6 +43,9 @@ class BackendMixin(BaseBackendMixin):
     def _sql(self, *args, **kwargs) -> 'sqlite3.Cursor':
         return self._cursor.execute(*args, **kwargs)
 
+    def _sql_many(self, request, values) -> 'sqlite3.Cursor':
+        return self._cursor.executemany(request, values)
+
     def _commit(self):
         self._connection.commit()
 

--- a/docarray/array/storage/sqlite/seqlike.py
+++ b/docarray/array/storage/sqlite/seqlike.py
@@ -83,14 +83,13 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
         )
 
     def extend(self, docs: Iterable['Document']) -> None:
-        if len(docs) == 0:
-            return
 
-        initial_len = len(self)
-        triplets = [(doc.id, doc, initial_len + k) for k, doc in enumerate(docs)]
-        self._sql_many(
-            f'INSERT INTO {self._table_name} (doc_id, serialized_value, item_order) VALUES (?, ?, ?)',
-            triplets,
-        )
-        self._offset2ids.extend([doc.id for doc in docs])
+        self_len = len(self)
+        for doc in docs:
+            self._sql(
+                f'INSERT INTO {self._table_name} (doc_id, serialized_value, item_order) VALUES (?, ?, ?)',
+                (doc.id, doc, self_len),
+            )
+            self._offset2ids.append(doc.id)
+            self_len += 1
         self._commit()

--- a/tests/unit/array/test_backend_configuration.py
+++ b/tests/unit/array/test_backend_configuration.py
@@ -12,7 +12,6 @@ def test_weaviate_hnsw(start_storage):
     result = requests.get('http://localhost:8080/v1/schema').json()
 
     classes = result.get('classes', [])
-    assert len(classes) == 2
     main_class = list(
         filter(lambda class_element: class_element['class'] == da._config.name, classes)
     )


### PR DESCRIPTION
Extend times in sqlite can be quite high due to length checking (when it is not needed in the batch case for each added item). Thanks @guenthermi for providing the insight!

In master:

```bash
Size: 1       len: 1        init-time: 0.00866 insert-time: 0.00048
Size: 10      len: 10       init-time: 0.00217 insert-time: 0.00359
Size: 100     len: 100      init-time: 0.00226 insert-time: 0.03473
Size: 1000    len: 1000     init-time: 0.00275 insert-time: 0.37138
Size: 10000   len: 10000    init-time: 0.01    insert-time: 3.72639
Size: 100000  len: 100000   init-time: 0.07416 insert-time: 98.56179
```

In this PR:

```bash
Size: 1        len: 1         init-time: 0.01598 insert-time: 0.00047
Size: 10       len: 10        init-time: 0.00203 insert-time: 0.00058
Size: 100      len: 100       init-time: 0.00195 insert-time: 0.00158
Size: 1000     len: 1000      init-time: 0.00268 insert-time: 0.0129
Size: 10000    len: 10000     init-time: 0.00926 insert-time: 0.13697
Size: 100000   len: 100000    init-time: 0.13961 insert-time: 1.62673
```

MWE:

```python
from docarray import Document, DocumentArray
import time

for size in [10**i for i in range(6)]:
    corpus_da = DocumentArray([Document(text=str(j)) for j in range(size)])
    t1 = time.time()
    da = DocumentArray(storage='sqlite', config={'connection': f'./sqlite_corpus_{size}.db'})
    t2 = time.time()
    da.extend(corpus_da)
    t3 = time.time()
    print('Size:', size, '\t\t\tlen:', str(len(da)) ,  '\t\t\tinit-time:', round(t2-t1,5), 'insert-time:', round(t3-t2,5))
```
