### PR TITLE
fix(qabot): hide the slot elements on the docs page

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -228,12 +228,14 @@
             title="DocArray Bot"
             description="The data structure for unstructured data"
     >
-        <dl>
-            <dt>You can ask questions about our docs. Try:</dt>
-            <dd>What is a DocumentArray?</dd>
-            <dd>How to use docarray with Jina?</dd>
-            <dd>How to find nearest neighbour of Documents?</dd>
-        </dl>
+        <template>
+            <dl>
+                <dt>You can ask questions about our docs. Try:</dt>
+                <dd>What is a DocumentArray?</dd>
+                <dd>How to use docarray with Jina?</dd>
+                <dd>How to find nearest neighbour of Documents?</dd>
+            </dl>
+        </template>
     </qa-bot>
 </div>
 <img referrerpolicy="no-referrer-when-downgrade"


### PR DESCRIPTION
Goals:
Add a template to prevent the qabot slot elements from showing on the docs pages.
