### PR TITLE
feat(hubble): use fixed domain for hubble api

### DIFF
--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -34,9 +34,7 @@ def _get_cloud_api() -> str:
     :return: Cloud Api Url
     """
     if 'JINA_HUBBLE_REGISTRY' in os.environ:
-        return os.environ['JINA_HUBBLE_REGISTRY']
-
-    return 'https://api.hubble.jina.ai'
+    return os.environ.get('JINA_HUBBLE_REGISTRY', 'https://api.hubble.jina.ai')
 
 
 class PushPullMixin:

--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -33,7 +33,6 @@ def _get_cloud_api() -> str:
 
     :return: Cloud Api Url
     """
-    if 'JINA_HUBBLE_REGISTRY' in os.environ:
     return os.environ.get('JINA_HUBBLE_REGISTRY', 'https://api.hubble.jina.ai')
 
 

--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -29,27 +29,14 @@ def _get_hub_config() -> Optional[Dict]:
 
 @lru_cache()
 def _get_cloud_api() -> str:
-    """Get Cloud Api for transmiting data to the cloud.
+    """Get Cloud Api for transmitting data to the cloud.
 
-    :raises RuntimeError: Encounter error when fetching the cloud Api Url.
     :return: Cloud Api Url
     """
     if 'JINA_HUBBLE_REGISTRY' in os.environ:
-        u = os.environ['JINA_HUBBLE_REGISTRY']
-    else:
-        try:
-            req = Request(
-                'https://api.jina.ai/hub/hubble.json',
-                headers={'User-Agent': 'Mozilla/5.0'},
-            )
-            with urlopen(req) as resp:
-                u = json.load(resp)['url']
-        except Exception as ex:
-            raise RuntimeError(
-                f'Can not fetch Cloud API address from {req.full_url}'
-            ) from ex
+        return os.environ['JINA_HUBBLE_REGISTRY']
 
-    return u
+    return 'https://api.hubble.jina.ai'
 
 
 class PushPullMixin:


### PR DESCRIPTION
Goals:

- `api.jina.ai` is unstable sometimes, remove this layer to get better quality. We need to maintain the old domain even we move to new domain anyway, so no worries about writing domain down directly. 

Related to https://github.com/jina-ai/hubble/issues/434