### PR TITLE
feat(sift-benchmark): use l2 squared dist for weaviate

### DIFF
--- a/scripts/benchmarking_dataset.py
+++ b/scripts/benchmarking_dataset.py
@@ -36,7 +36,7 @@ def get_configuration_storage_backends(argparse):
 
     if args.default_hnsw:
         storage_backends = [
-            ('weaviate', {'n_dim': D}),
+                ('weaviate', {'n_dim': D, 'distance': 'l2-squared'}),
             (
                 'annlite',
                 {'n_dim': D},
@@ -50,7 +50,7 @@ def get_configuration_storage_backends(argparse):
         storage_backends = [
             (
                 'weaviate',
-                {'n_dim': D, 'ef': 100, 'ef_construction': 100, 'max_connections': 16},
+                {'n_dim': D, 'ef': 100, 'ef_construction': 100, 'max_connections': 16, 'distance': 'l2-squared'},
             ),
             (
                 'annlite',


### PR DESCRIPTION
closes #360

Assumes #359 was already merged. I **did not** rebase this on the other branch or merge the other one in here, as I want to leave this to you. This will not create any conflicts, but at the same time the feature won't be used if the changes from #359 are not presetn.

Goals:

- [x] use l2 distance in sift benchmark for Weaviate
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
