### PR TITLE
feat: add warning for non vector embeddings

### DIFF
--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -3,8 +3,9 @@ import random
 from collections import defaultdict
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+import warnings
 
-from ..math.ndarray import check_arraylike_equality
+from ..math.ndarray import check_arraylike_equality, is_vector
 
 if TYPE_CHECKING:
     from ..score import NamedScore
@@ -56,6 +57,9 @@ class DocumentData:
     offset: Optional[float] = None
     location: Optional[List[float]] = None
     embedding: Optional['ArrayType'] = field(default=None, hash=False, compare=False)
+    _embedding: Optional['ArrayType'] = field(
+        init=False, repr=False, hash=False, compare=False
+    )
     modality: Optional[str] = None
     evaluations: Optional[Dict[str, Union['NamedScore', Dict]]] = None
     scores: Optional[Dict[str, Union['NamedScore', Dict]]] = None
@@ -156,3 +160,16 @@ class DocumentData:
                 if getattr(self, key) != getattr(other, key):
                     return False
         return True
+
+    @property
+    def embedding(self):
+        return self._embedding
+
+    @embedding.setter
+    def embedding(self, value: 'ArrayType'):
+        if not is_vector(value):
+            warnings.warn(
+                'Your embedding should be a vector, function like find or match will break otherwise '
+            )
+
+        self._embedding = value

--- a/docarray/document/mixins/property.py
+++ b/docarray/document/mixins/property.py
@@ -1,7 +1,9 @@
 import mimetypes
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from ._property import _PropertyMixin
+from ...math.ndarray import is_vector
 
 if TYPE_CHECKING:
     from ...typing import DocumentContentType, ArrayType
@@ -86,6 +88,16 @@ class PropertyMixin(_PropertyMixin):
             value = MatchArray(value, reference_doc=self._data._reference_doc)
 
         self._data.matches = value
+
+    @_PropertyMixin.embedding.setter
+    def embedding(self, value: 'ArrayType'):
+
+        if is_vector(value):
+            warnings.warn(
+                'Your embedding should be a vector, function like find or match will break otherwise '
+            )
+
+        self._data.embedding = value
 
     @property
     def content_type(self) -> Optional[str]:

--- a/docarray/document/mixins/property.py
+++ b/docarray/document/mixins/property.py
@@ -1,9 +1,7 @@
 import mimetypes
-import warnings
 from typing import TYPE_CHECKING, Optional
 
 from ._property import _PropertyMixin
-from ...math.ndarray import is_vector
 
 if TYPE_CHECKING:
     from ...typing import DocumentContentType, ArrayType
@@ -88,16 +86,6 @@ class PropertyMixin(_PropertyMixin):
             value = MatchArray(value, reference_doc=self._data._reference_doc)
 
         self._data.matches = value
-
-    @_PropertyMixin.embedding.setter
-    def embedding(self, value: 'ArrayType'):
-
-        if is_vector(value):
-            warnings.warn(
-                'Your embedding should be a vector, function like find or match will break otherwise '
-            )
-
-        self._data.embedding = value
 
     @property
     def content_type(self) -> Optional[str]:

--- a/docarray/math/ndarray.py
+++ b/docarray/math/ndarray.py
@@ -289,3 +289,24 @@ def detach_tensor_if_present(x: Any) -> Any:
 
         x = torch.tensor(x.detach().numpy())
     return x
+
+
+def is_vector(array: 'ArrayType') -> bool:
+    framework, _ = get_array_type(array)
+    if framework in ['numpy', 'torch', 'scipy', 'paddle', 'tensorflow']:
+        if len(array.shape) == 1:  # shape : (100,)
+            return True
+
+        elif len(array.shape) == 2:
+            if array.shape[0] == 1 or array.shape[1] == 1:  # shape : (1,100) or (100,1)
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    elif framework == 'python':
+        return True
+
+    else:
+        return False

--- a/tests/unit/document/test_ndarray.py
+++ b/tests/unit/document/test_ndarray.py
@@ -33,3 +33,37 @@ def test_ndarray_force_numpy(ndarray_val, attr, is_sparse):
     assert type(getattr(Document.from_protobuf(d.to_protobuf()), attr)) is type(
         ndarray_val
     )
+
+
+def get_wrong_embeddings():
+    a = np.zeros((5, 100))
+    return [
+        a,
+        # torch.tensor(a),
+        # tf.constant(a),
+        # paddle.to_tensor(a),
+        # torch.tensor(a).to_sparse(),
+        # csr_matrix(a),
+        # bsr_matrix(a),
+        # coo_matrix(a),
+        # csc_matrix(a),
+    ]
+
+
+@pytest.mark.parametrize('ndarray_val', get_wrong_embeddings())
+def test_wrong_embedding_shape_init(ndarray_val):
+
+    with pytest.warns(UserWarning, match='embedding should be a vector') as record:
+        Document(embedding=ndarray_val)
+
+    assert len(record) == 1
+
+
+@pytest.mark.parametrize('ndarray_val', get_wrong_embeddings())
+def test_wrong_embedding_shape_setter(ndarray_val):
+
+    d = Document()
+    with pytest.warns(UserWarning, match='embedding should be a vector') as record:
+        d.embedding = ndarray_val
+
+    assert len(record) == 1


### PR DESCRIPTION
Goals : warning user when instantiating a Document with an embedding which is not a vector (i.e one dimension ndarray)

fix : https://github.com/jina-ai/docarray/issues/351
