### PR TITLE
fix: fix protobuf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         # req usage, please see https://docarray.jina.ai/#install
         'common': [
-            'protobuf>=3.13.0',
+            'protobuf>=3.13.0,<4.21.0',
             'lz4',
             'requests',
             'matplotlib',
@@ -52,7 +52,7 @@ setup(
             'uvicorn',
         ],
         'full': [
-            'protobuf>=3.13.0',
+            'protobuf>=3.13.0,<4.21.0',
             'lz4',
             'requests',
             'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         # req usage, please see https://docarray.jina.ai/#install
         'common': [
-            'protobuf>=3.13.0,<4.21.0',
+            'protobuf>=3.13.0,<=3.20.1',
             'lz4',
             'requests',
             'matplotlib',
@@ -52,7 +52,7 @@ setup(
             'uvicorn',
         ],
         'full': [
-            'protobuf>=3.13.0,<4.21.0',
+            'protobuf>=3.13.0,<=3.20.1',
             'lz4',
             'requests',
             'matplotlib',


### PR DESCRIPTION
recent release in protobuf causes the following problem:
```text
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be 
regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 ```
As a quick fix, we fix the protobuf version to less than 4.21
The best solution would be to regenerate proto with protoc >= 3.19.0