### PR TITLE
feat: add filter to match method

### DIFF
--- a/docarray/array/mixins/match.py
+++ b/docarray/array/mixins/match.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, Tuple, TYPE_CHECKING
+from typing import Optional, Union, Callable, Tuple, TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     import numpy as np
@@ -20,6 +20,7 @@ class MatchMixin:
         metric_name: Optional[str] = None,
         batch_size: Optional[int] = None,
         exclude_self: bool = False,
+        filter: Optional[Dict] = None,
         only_id: bool = False,
         use_scipy: bool = False,
         device: str = 'cpu',
@@ -50,6 +51,7 @@ class MatchMixin:
             elements. When `darray` is big, this can significantly speedup the computation.
         :param exclude_self: if set, Documents in ``darray`` with same ``id`` as the left-hand values will not be
                         considered as matches.
+        :param filter: filter query used for pre-filtering or filtering
         :param only_id: if set, then returning matches will only contain ``id``
         :param use_scipy: if set, use ``scipy`` as the computation backend. Note, ``scipy`` does not support distance
             on sparse matrix.
@@ -76,6 +78,7 @@ class MatchMixin:
             metric_name=metric_name,
             batch_size=batch_size,
             exclude_self=exclude_self,
+            filter=filter,
             only_id=only_id,
             use_scipy=use_scipy,
             device=device,


### PR DESCRIPTION
This PR add the ability to do pre-filtering when calling `match`. Under the hood it passed the filter to the `find` function.

```python
 doc.match(da, filter=filter)
```

- [ ] code
- [ ] tests
- [ ] docs