### PR TITLE
fix(tests): eq and neq operator for qdrant filtering 

### DIFF
--- a/tests/unit/array/mixins/test_find.py
+++ b/tests/unit/array/mixins/test_find.py
@@ -305,6 +305,8 @@ def test_search_pre_filtering(
 
         results = da.find(np.random.rand(n_dim), filter=filter)
 
+        assert len(results) > 0
+
         assert all(
             [numeric_operators[operator](r.tags['price'], threshold) for r in results]
         )

--- a/tests/unit/array/mixins/test_find.py
+++ b/tests/unit/array/mixins/test_find.py
@@ -257,19 +257,26 @@ numeric_operators_qdrant = {
             )
             for operator in ['gte', 'gt', 'lte', 'lt']
         ],
-        *[
-            tuple(
-                [
-                    'qdrant',
-                    lambda operator, threshold: {
-                        'must': [{'key': 'price', 'value': {operator: threshold}}]
-                    },
-                    numeric_operators_qdrant,
-                    operator,
-                ]
-            )
-            for operator in ['eq', 'neq']
-        ],
+        tuple(
+            [
+                'qdrant',
+                lambda operator, threshold: {
+                    'must': [{'key': 'price', 'match': {'value': threshold}}]
+                },
+                numeric_operators_qdrant,
+                'eq',
+            ]
+        ),
+        tuple(
+            [
+                'qdrant',
+                lambda operator, threshold: {
+                    'must_not': [{'key': 'price', 'match': {'value': threshold}}]
+                },
+                numeric_operators_qdrant,
+                'neq',
+            ]
+        ),
         *[
             tuple(
                 [

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -639,19 +639,26 @@ numeric_operators_qdrant = {
             )
             for operator in ['gte', 'gt', 'lte', 'lt']
         ],
-        *[
-            tuple(
-                [
-                    'qdrant',
-                    lambda operator, threshold: {
-                        'must': [{'key': 'price', 'value': {operator: threshold}}]
-                    },
-                    numeric_operators_qdrant,
-                    operator,
-                ]
-            )
-            for operator in ['eq', 'neq']
-        ],
+        tuple(
+            [
+                'qdrant',
+                lambda operator, threshold: {
+                    'must': [{'key': 'price', 'match': {'value': threshold}}]
+                },
+                numeric_operators_qdrant,
+                'eq',
+            ]
+        ),
+        tuple(
+            [
+                'qdrant',
+                lambda operator, threshold: {
+                    'must_not': [{'key': 'price', 'match': {'value': threshold}}]
+                },
+                numeric_operators_qdrant,
+                'neq',
+            ]
+        ),
         *[
             tuple(
                 [
@@ -687,6 +694,8 @@ def test_match_pre_filtering(
 
         doc = Document(embedding=np.random.rand(n_dim))
         doc.match(da, filter=filter)
+
+        assert len(doc.matches) > 0
 
         assert all(
             [


### PR DESCRIPTION
# Context
Pre-filtering with the operator equal is not working with qdrant backend. See full issue for details https://github.com/jina-ai/docarray/issues/387


# Solution
To do filtering with with `eq` and `neq` one should use the `match` keyword.

for `eq`:

`filter = {'must': [{'key': 'price', 'match': {'value': 7}}]}`

for `neq`:

filter = {'must_not': [{'key': 'price', 'match': {'value': 7}}]}

# What this pr do
This pr fix the test to use this notation for the filter

