### PR TITLE
fix: convert mesh tensor to nparray

### DIFF
--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     from ...typing import T
 
@@ -31,10 +33,10 @@ class MeshDataMixin:
             scene = loader(self.uri, force='scene')
             for geo in scene.geometry.values():
                 geo: trimesh.Trimesh
-                self.chunks.append(Document(tensor=geo.sample(samples)))
+                self.chunks.append(Document(tensor=np.array(geo.sample(samples))))
         else:
             # combine a scene into a single mesh
             mesh = loader(self.uri, force='mesh')
-            self.tensor = mesh.sample(samples)
+            self.tensor = np.array(mesh.sample(samples))
 
         return self

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -247,6 +247,7 @@ def test_glb_converters(uri, chunk_num):
     doc = Document(uri=uri)
     doc.load_uri_to_point_cloud_tensor(2000)
     assert doc.tensor.shape == (2000, 3)
+    assert isinstance(doc.tensor, np.ndarray)
 
     doc.load_uri_to_point_cloud_tensor(2000, as_chunks=True)
     assert len(doc.chunks) == chunk_num


### PR DESCRIPTION
Summary:

This PR convert mesh tensor get from `load_uri_to_point_cloud_tensor` to numpy array.

Description:

We use `Trimesh` APIs in this method and it returns a datatype of `<class 'trimesh.caching.TrackedArray'>` which is a subclass of numpy array ([reference](https://trimsh.org/trimesh.caching.html#trimesh.caching.tracked_array)). This may cause some data type problems in downstream applications.