### PR TITLE
fix: skip render long uri

### DIFF
--- a/docarray/document/mixins/image.py
+++ b/docarray/document/mixins/image.py
@@ -10,6 +10,7 @@ from .helper import _get_file_context, _uri_to_blob
 
 if TYPE_CHECKING:
     from ...typing import T
+    from PIL.Image import Image as PILImage
 
 
 class ImageDataMixin:
@@ -27,6 +28,19 @@ class ImageDataMixin:
         """
         self.tensor = _move_channel_axis(
             self.tensor, original_channel_axis, new_channel_axis
+        )
+        return self
+
+    def load_pil_image_to_datauri(self, image: 'PILImage'):
+        """Convert a pillow image into a datauri with header `data:image/png`.
+
+        :param image: a pillow image
+        :return: itself after processed
+        """
+        buffer = io.BytesIO()
+        image.save(buffer, format='png')
+        self.uri = (
+            f'data:image/png;base64,' + base64.b64encode(buffer.getvalue()).decode()
         )
         return self
 

--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -25,7 +25,7 @@ class PlotMixin:
         for f in self.non_empty_fields:
             if f.startswith('_'):
                 continue
-            elif f in ('text', 'blob') and len(getattr(self, f)) > 100:
+            elif f in ('text', 'blob', 'uri') and len(getattr(self, f)) > 100:
                 v = getattr(self, f)
                 my_table.add_row(f, str(v)[:100] + f'... [dim](length: {len(v)})')
             elif f in ('embedding', 'tensor'):

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -115,6 +115,19 @@ def test_convert_image_tensor_to_uri(arr_size, channel_axis, width, height, form
     assert doc.tensor.any()  # assure after conversion tensor still exist.
 
 
+def test_convert_pillow_image_to_uri():
+    doc = Document(content=np.random.randint(0, 255, [32, 32, 3]))
+    assert doc.tensor.any()
+    assert not doc.uri
+    import PIL.Image
+
+    p = PIL.Image.fromarray(doc.tensor, mode='RGB')
+    doc.load_pil_image_to_datauri(p)
+    assert doc.uri.startswith(f'data:image/png;base64,')
+    assert doc.mime_type == 'image/png'
+    assert doc.tensor.any()  # assure after conversion tensor still exist.
+
+
 @pytest.mark.xfail(
     condition=__windows__, reason='x-python is not detected on windows CI'
 )


### PR DESCRIPTION
Long uri makes rich render in notebook extremely slow