### PR TITLE
fix(elastic): inconsistent offset on bulk index error and improve bulk performance

### DIFF
--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -161,7 +161,7 @@ class BackendMixin(BaseBackendMixin):
     def _send_requests(self, request):
         failed_index = []
         for success, info in parallel_bulk(self._client, request, raise_on_error=False):
-            if success is not True:
+            if not success:
                 failed_index.append(info['index'])
 
         return failed_index

--- a/docarray/array/storage/elastic/seqlike.py
+++ b/docarray/array/storage/elastic/seqlike.py
@@ -85,8 +85,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             ]
         )
 
-        if len(failed_ids)>0:
+        if len(failed_ids) > 0:
             err_msg = f'fail to add Documents with ids: {failed_ids}'
             warnings.warn(err_msg)
             raise IndexError(err_msg)
-

--- a/docarray/array/storage/elastic/seqlike.py
+++ b/docarray/array/storage/elastic/seqlike.py
@@ -1,4 +1,5 @@
 from typing import Union, Iterable, Dict
+import warnings
 
 from ..base.seqlike import BaseSequenceLikeMixin
 from .... import Document
@@ -83,3 +84,9 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
                 if (doc.id not in self._offset2ids.ids) and (doc.id not in failed_ids)
             ]
         )
+
+        if len(failed_ids)>0:
+            err_msg = f'fail to add Documents with ids: {failed_ids}'
+            warnings.warn(err_msg)
+            raise IndexError(err_msg)
+

--- a/tests/unit/array/storage/elastic/test_add.py
+++ b/tests/unit/array/storage/elastic/test_add.py
@@ -1,6 +1,6 @@
 from docarray import Document, DocumentArray
-import pytest
 
+import pytest
 
 def test_add_ignore_existing_doc_id(start_storage):
     elastic_doc = DocumentArray(
@@ -63,18 +63,19 @@ def test_add_skip_wrong_data_type_and_fix_offset(start_storage):
             ]
         )
 
-    with elastic_doc:
-        elastic_doc.extend(
-            [
-                Document(id='0', price=10000),
-                Document(id='1', price=20000),
-                Document(id='3', price=30000),
-                Document(id='4', price=100000000000),  # overflow int32
-                Document(id='5', price=2000),
-                Document(id='6', price=100000000000),  # overflow int32
-                Document(id='7', price=30000),
-            ]
-        )
+    with pytest.raises(IndexError):
+        with elastic_doc:
+            elastic_doc.extend(
+                [
+                    Document(id='0', price=10000),
+                    Document(id='1', price=20000),
+                    Document(id='3', price=30000),
+                    Document(id='4', price=100000000000),  # overflow int32
+                    Document(id='5', price=2000),
+                    Document(id='6', price=100000000000),  # overflow int32
+                    Document(id='7', price=30000),
+                ]
+            )
 
     expected_ids = ["0", "1", "2", "3", "5", "7"]
 

--- a/tests/unit/array/storage/elastic/test_add.py
+++ b/tests/unit/array/storage/elastic/test_add.py
@@ -41,3 +41,30 @@ def test_add_ignore_existing_doc_id(start_storage):
     assert len(elastic_doc) == len(elastic_doc[:, 'embedding'])
     assert len(elastic_doc) == indexed_offset_count
     assert len(elastic_doc[:, 'embedding']) == 7
+
+
+def test_add_skip_wrong_data_type_and_fix_offset():
+    elastic_doc = DocumentArray(
+        storage='elasticsearch',
+        config={
+            'columns': [('price', 'int')],
+            'index_name': 'test_add_skip_wrong_data_type_and_fix_offset',
+        },
+    )
+
+    with elastic_doc:
+        elastic_doc.extend(
+            [
+                Document(id='0', price=1000),
+                Document(id='1', price=20000),
+                Document(id='2', price=103000),
+            ]
+        )
+
+    with elastic_doc:
+        elastic_doc.extend(
+            [
+                Document(id='0', price=100000000000),
+                Document(id='1', price=20000),
+            ]
+        )

--- a/tests/unit/array/storage/elastic/test_add.py
+++ b/tests/unit/array/storage/elastic/test_add.py
@@ -2,6 +2,7 @@ from docarray import Document, DocumentArray
 
 import pytest
 
+
 def test_add_ignore_existing_doc_id(start_storage):
     elastic_doc = DocumentArray(
         storage='elasticsearch',
@@ -77,9 +78,9 @@ def test_add_skip_wrong_data_type_and_fix_offset(start_storage):
                 ]
             )
 
-    expected_ids = ["0", "1", "2", "3", "5", "7"]
+    expected_ids = ['0', '1', '2', '3', '5', '7']
 
     assert len(elastic_doc) == 6
-    assert len(elastic_doc[:, "id"]) == 6
-    assert elastic_doc[:, "id"] == expected_ids
+    assert len(elastic_doc[:, 'id']) == 6
+    assert elastic_doc[:, 'id'] == expected_ids
     assert elastic_doc._offset2ids.ids == expected_ids

--- a/tests/unit/array/storage/elastic/test_add.py
+++ b/tests/unit/array/storage/elastic/test_add.py
@@ -1,4 +1,5 @@
 from docarray import Document, DocumentArray
+import pytest
 
 
 def test_add_ignore_existing_doc_id(start_storage):
@@ -43,10 +44,11 @@ def test_add_ignore_existing_doc_id(start_storage):
     assert len(elastic_doc[:, 'embedding']) == 7
 
 
-def test_add_skip_wrong_data_type_and_fix_offset():
+def test_add_skip_wrong_data_type_and_fix_offset(start_storage):
     elastic_doc = DocumentArray(
         storage='elasticsearch',
         config={
+            'n_dim': 3,
             'columns': [('price', 'int')],
             'index_name': 'test_add_skip_wrong_data_type_and_fix_offset',
         },
@@ -64,7 +66,19 @@ def test_add_skip_wrong_data_type_and_fix_offset():
     with elastic_doc:
         elastic_doc.extend(
             [
-                Document(id='0', price=100000000000),
+                Document(id='0', price=10000),
                 Document(id='1', price=20000),
+                Document(id='3', price=30000),
+                Document(id='4', price=100000000000),  # overflow int32
+                Document(id='5', price=2000),
+                Document(id='6', price=100000000000),  # overflow int32
+                Document(id='7', price=30000),
             ]
         )
+
+    expected_ids = ["0", "1", "2", "3", "5", "7"]
+
+    assert len(elastic_doc) == 6
+    assert len(elastic_doc[:, "id"]) == 6
+    assert elastic_doc[:, "id"] == expected_ids
+    assert elastic_doc._offset2ids.ids == expected_ids


### PR DESCRIPTION
Goals:

On bulk index submit, if there is error occured ( for example if data type provided is wrong ( in test, I give example by providing int64 data inserted into int32 column )), it will raise BulkIndexError, however the documents is still inserted to the main index but due to error raises, the offset is not updated.

In this PR, I try to fix the issue and also increase the performance by using parallel_bulk and set raise_on_error to False, then return the index error info to the caller

speed benchmark result :

1000 Docs, emb dim = 3, average of 20 runs

with parallel bulk, 4 thread = 15.89 s
with bulk = 21.34 s

- ...
- ...
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
