### PR TITLE
feat: allow modalities of multimodal docs to be accessed

### DIFF
--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -141,10 +141,13 @@ class MultiModalMixin:
         return doc, attribute_type
 
     def __getattr__(self, attr):
-        has_metadata = (
-            super().__getattribute__('_data') is not None
-            and getattr(self._data, '_metadata') is not None
-        )
+        try:
+            data = super().__getattribute__('_data')
+            has_data = bool(data)
+        except AttributeError:
+            has_data = False
+
+        has_metadata = has_data and getattr(self._data, '_metadata') is not None
         if (
             has_metadata
             and self.is_multimodal

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -139,3 +139,10 @@ class MultiModalMixin:
         else:
             raise ValueError(f'Unsupported type annotation')
         return doc, attribute_type
+
+    def __getattr__(self, attr):
+        if self.is_multimodal and attr in self._metadata['multi_modal_schema']:
+            content = self.get_multi_modal_attribute(attr)[:, 'content']
+            return content[0] if len(content) == 1 else content
+        else:
+            raise AttributeError(f'{self.__class__.__name__} has no attribute {attr}')

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -142,7 +142,15 @@ class MultiModalMixin:
         return doc, attribute_type
 
     def __getattr__(self, attr):
-        if self.is_multimodal and attr in self._metadata['multi_modal_schema']:
+        has_metadata = (
+            super().__getattribute__('_data') is not None
+            and getattr(self._data, '_metadata') is not None
+        )
+        if (
+            has_metadata
+            and self.is_multimodal
+            and attr in self._metadata['multi_modal_schema']
+        ):
             mm_attr_da = self.get_multi_modal_attribute(attr)
             collected_attributes = []
             for d in mm_attr_da:

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -116,8 +116,7 @@ class MultiModalMixin:
         position = self._metadata['multi_modal_schema'][attribute].get('position')
 
         if attribute_type in [AttributeType.DOCUMENT, AttributeType.NESTED]:
-            d = DocumentArray([self.chunks[int(position)]])
-            return d
+            return DocumentArray([self.chunks[int(position)]])
         elif attribute_type in [
             AttributeType.ITERABLE_DOCUMENT,
             AttributeType.ITERABLE_NESTED,

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -154,16 +154,6 @@ class MultiModalMixin:
             and attr in self._metadata['multi_modal_schema']
         ):
             mm_attr_da = self.get_multi_modal_attribute(attr)
-            collected_attributes = []
-            for d in mm_attr_da:
-                if d.is_multimodal:  # comes from nested dataclass, add Document as is
-                    collected_attributes.append(d)
-                else:  # comes from a non-nested attribute, add the value
-                    collected_attributes.append(d.content)
-            return (
-                collected_attributes
-                if len(collected_attributes) > 1
-                else collected_attributes[0]
-            )
+            return mm_attr_da if len(mm_attr_da) > 1 else mm_attr_da[0]
         else:
             raise AttributeError(f'{self.__class__.__name__} has no attribute {attr}')

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -674,7 +674,7 @@ def test_access_multimodal(serialization):
     MyText = TypeVar('MyText', bound=str)
 
     def my_setter(value) -> 'Document':
-        return Document(text=value + ' but custom!')
+        return Document(text=value + ' but custom!', tags={'custom': 'tag'})
 
     def my_getter(doc: 'Document'):
         return doc.text
@@ -700,6 +700,7 @@ def test_access_multimodal(serialization):
     assert d.description.content == 'hello, world'
     assert isinstance(d.heading, Document)
     assert d.heading.content == 'hello, world but custom!'
+    assert d.heading.tags == {'custom': 'tag'}
     assert isinstance(d.heading_list, DocumentArray)
     assert d.heading_list.texts == ['hello', 'world']
 
@@ -713,6 +714,7 @@ def test_access_multimodal(serialization):
     assert d.description.content == 'hello, beautiful world'
     assert isinstance(d.heading, Document)
     assert d.heading.content == 'hello, world but beautifully custom!'
+    assert d.heading.tags == {'custom': 'tag'}
     assert isinstance(d.heading_list, DocumentArray)
     assert d.heading_list.texts == ['hello', 'beautiful', 'world']
 

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -631,7 +631,6 @@ def test_field_fn():
     assert m1 == m2
 
 
-<<<<<<< HEAD
 def _serialize_deserialize(doc, serialization_type):
     if serialization_type == 'protobuf':
         return Document.from_protobuf(doc.to_protobuf())
@@ -694,12 +693,17 @@ def test_acess_multimodal(serialization):
         heading_list=['hello', 'world'],
     )
     d = Document(m)
+    if serialization:
+        d = _serialize_deserialize(d, serialization)
     assert d.description == 'hello, world'
     assert d.heading == 'hello, world but custom!'
     assert d.heading_list == ['hello', 'world']
 
 
-def test_access_multimodal_nested():
+@pytest.mark.parametrize(
+    'serialization', [None, 'protobuf', 'pickle', 'json', 'dict', 'base64']
+)
+def test_access_multimodal_nested(serialization):
     MyText = TypeVar('MyText', bound=str)
 
     def my_setter(value) -> 'Document':
@@ -735,6 +739,8 @@ def test_access_multimodal_nested():
 
     m = MyMultiModalDoc(other_doc=inner_doc, other_doc_list=inner_doc_list)
     d = Document(m)
+    if serialization:
+        d = _serialize_deserialize(d, serialization)
     assert isinstance(d.other_doc, Document)
     assert d.other_doc.heading == 'inner hello, world but custom!'
     assert isinstance(d.other_doc_list, list)

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -699,6 +699,14 @@ def test_acess_multimodal(serialization):
     assert d.heading == 'hello, world but custom!'
     assert d.heading_list == ['hello', 'world']
 
+    d.description = 'hello, beautiful world'
+    d.heading = 'hello, world but beautifully custom!'
+    d.heading_list = ['hello', 'beautiful', 'world']
+
+    assert d.description == 'hello, beautiful world'
+    assert d.heading == 'hello, world but beautifully custom!'
+    assert d.heading_list == ['hello', 'beautiful', 'world']
+
 
 @pytest.mark.parametrize(
     'serialization', [None, 'protobuf', 'pickle', 'json', 'dict', 'base64']
@@ -746,3 +754,11 @@ def test_access_multimodal_nested(serialization):
     assert isinstance(d.other_doc_list, list)
     assert isinstance(d.other_doc_list[0], Document)
     assert d.other_doc_list[1].heading == '1 inner list hello, world but custom!'
+
+    d.other_doc.heading = 'inner hello, beautiful world but custom!'
+    d.other_doc_list[1].heading = '1 inner list hello, beautiful world but custom!'
+
+    assert d.other_doc.heading == 'inner hello, beautiful world but custom!'
+    assert (
+        d.other_doc_list[1].heading == '1 inner list hello, beautiful world but custom!'
+    )

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -682,7 +682,7 @@ class InnerDoc:
 
 
 @dataclass
-class MyMultiModalDoc:
+class NestedMultiModalDoc:
     other_doc: InnerDoc
     other_doc_list: List[InnerDoc]
 
@@ -703,7 +703,7 @@ def nested_mmdoc():
         )
         for i in range(3)
     ]
-    return MyMultiModalDoc(other_doc=inner_doc, other_doc_list=inner_doc_list)
+    return NestedMultiModalDoc(other_doc=inner_doc, other_doc_list=inner_doc_list)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -631,6 +631,7 @@ def test_field_fn():
     assert m1 == m2
 
 
+<<<<<<< HEAD
 def _serialize_deserialize(doc, serialization_type):
     if serialization_type == 'protobuf':
         return Document.from_protobuf(doc.to_protobuf())
@@ -667,7 +668,10 @@ def test_multimodal_serialize_deserialize(serialization):
     assert _metadata_before == doc._metadata
 
 
-def test_acess_multimodal():
+@pytest.mark.parametrize(
+    'serialization', [None, 'protobuf', 'pickle', 'json', 'dict', 'base64']
+)
+def test_acess_multimodal(serialization):
     MyText = TypeVar('MyText', bound=str)
 
     def my_setter(value) -> 'Document':
@@ -684,7 +688,7 @@ def test_acess_multimodal():
         heading: MyText = field(setter=my_setter, getter=my_getter, default='')
 
     m = MyMultiModalDoc(
-        avatar='toydata/test.png',
+        avatar=os.path.join(cur_dir, 'toydata/test.png'),
         description='hello, world',
         heading='hello, world',
         heading_list=['hello', 'world'],
@@ -716,13 +720,13 @@ def test_access_multimodal_nested():
         other_doc_list: List[InnerDoc]
 
     inner_doc = InnerDoc(
-        avatar='toydata/test.png',
+        avatar=os.path.join(cur_dir, 'toydata/test.png'),
         description='inner hello, world',
         heading='inner hello, world',
     )
     inner_doc_list = [
         InnerDoc(
-            avatar='toydata/test.png',
+            avatar=os.path.join(cur_dir, 'toydata/test.png'),
             description='inner list hello, world',
             heading=f'{i} inner list hello, world',
         )


### PR DESCRIPTION
This allows Documents that come from a multimodal dataclass to expose their multimodal attributes like any other 'native' attribute (check last line in the code snippet):

```python
MyText = TypeVar('MyText', bound=str)


def my_setter(value) -> 'Document':
    return Document(text=value + ' but custom!')


def my_getter(doc: 'Document'):
    return doc.text


@dataclass
class MyMultiModalDoc:
    avatar: Image
    description: Text
    heading: MyText = field(setter=my_setter, getter=my_getter, default='')


m = MyMultiModalDoc(avatar='testflow.jpg', description='hello, world', heading='hello, world')
d = Document(m)
print(d.heading)  # prints a Document with text='hello, world but custom!'
print(d.heading.text)  # prints 'hello, world but custom!'
```

This also extends to use inside of an Executor:

```python
class MyExec(Executor):
    @requests
    def foo(self, docs, **kwargs):
        model = ...  # embedding model
        for d in docs:
            d.heading.embed(model)
```

**Advanced usage example**

This also handles list-types, nested dataclasses, and list-types of nested data classes:

<details>
  <summary>Click to expand: Advanced example </summary>

```python
MyText = TypeVar('MyText', bound=str)


def my_setter(value) -> 'Document':
    return Document(text=value + ' but custom!')


def my_getter(doc: 'Document'):
    return doc.text


@dataclass
class InnerDoc:
    avatar: Image
    description: Text
    heading: MyText = field(setter=my_setter, getter=my_getter, default='')


@dataclass
class MyMultiModalDoc:
    avatar: Image
    description: Text
    heading_list: List[Text]
    other_doc: InnerDoc
    other_doc_list: List[InnerDoc]
    heading: MyText = field(setter=my_setter, getter=my_getter, default='')


inner_doc_list = [InnerDoc(avatar='testflow.jpg', description='hello, world', heading=f'{i} hello, world') for i in range(3)]

m = MyMultiModalDoc(avatar='testflow.jpg', description='hello, world', heading='hello, world',
                    heading_list=['hello', 'world'], other_doc=InnerDoc(avatar='testflow.jpg',
                                                                        description='inner hello, world',
                                                                        heading='inner hello, world'),
                    other_doc_list=inner_doc_list)
d = Document(m)
print(d.heading.text)  # returns 'hello, world but custom!'
print(d.heading_list.texts)  # returns ['hello', 'world']
print(d.other_doc)  # returns the inner doc
print(d.other_doc.heading.text)  # returns 'inner hello, world but custom!'
print(d.other_doc_list)  # returns DocArray of inner docs
print(d.other_doc_list[1].heading.text)  # returns '1 inner hello, world but custom!'
```
</details>


This should solve the issue of multimodal features not being easily usable inside of Jina.

**Still TODO:**
- [x] support for list-like multimodal types
- [x] support for nested dataclasse
- [x]~~make sure that `content` is always the desired return value~~
- [x] tests
- [ ]~~support custom getters~~ getters are only called when performng `MMDoc(d)`, not when doing `d.attr`. so not relevant here
- [x] support json and dict (de)serialization with this feature **Edit**: This is done separately here: jina-ai/docarray/issues/429]
- [ ] documentation

