### PR TITLE
fix: keep _metadata when serializing to dict and json

### DIFF
--- a/docarray/document/pydantic_model.py
+++ b/docarray/document/pydantic_model.py
@@ -65,9 +65,7 @@ class PydanticDocument(BaseModel):
         _metadata = data.get('_metadata', None)
         if _metadata is not None:
             _MetadataModel(metadata=_metadata)  # validate _metadata
-            object.__setattr__(
-                self, '_metadata', _metadata
-            )  # if no exception, assign _metadata
+            object.__setattr__(self, '_metadata', _metadata)
 
 
 PydanticDocument.update_forward_refs()

--- a/docarray/document/pydantic_model.py
+++ b/docarray/document/pydantic_model.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Dict, Any, TYPE_CHECKING, Union
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, PrivateAttr
 
 from ..math.ndarray import to_list
 
@@ -12,6 +12,7 @@ _ProtoValueType = Optional[Union[bool, float, str, list, dict]]
 _StructValueType = Union[
     _ProtoValueType, List[_ProtoValueType], Dict[str, _ProtoValueType]
 ]
+_MetadataType = Dict[str, _StructValueType]
 
 
 def _convert_ndarray_to_list(v: 'ArrayType'):
@@ -24,6 +25,10 @@ class _NamedScore(BaseModel):
     op_name: Optional[str] = None
     description: Optional[str] = None
     ref_id: Optional[str] = None
+
+
+class _MetadataModel(BaseModel):
+    metadata: _MetadataType
 
 
 class PydanticDocument(BaseModel):
@@ -53,6 +58,16 @@ class PydanticDocument(BaseModel):
 
     class Config:
         smart_union = True
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        # underscore attributes need to be set and validated manually
+        _metadata = data.get('_metadata', None)
+        if _metadata is not None:
+            _MetadataModel(metadata=_metadata)  # validate _metadata
+            object.__setattr__(
+                self, '_metadata', _metadata
+            )  # if no exception, assign _metadata
 
 
 PydanticDocument.update_forward_refs()

--- a/docarray/document/pydantic_model.py
+++ b/docarray/document/pydantic_model.py
@@ -64,8 +64,8 @@ class PydanticDocument(BaseModel):
         # underscore attributes need to be set and validated manually
         _metadata = data.get('_metadata', None)
         if _metadata is not None:
-            _MetadataModel(metadata=_metadata)  # validate _metadata
-            object.__setattr__(self, '_metadata', _metadata)
+            _md_model = _MetadataModel(metadata=_metadata)  # validate _metadata
+            object.__setattr__(self, '_metadata', _md_model.metadata)
 
 
 PydanticDocument.update_forward_refs()

--- a/docarray/document/pydantic_model.py
+++ b/docarray/document/pydantic_model.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Dict, Any, TYPE_CHECKING, Union
 
-from pydantic import BaseModel, validator, PrivateAttr
+from pydantic import BaseModel, validator
 
 from ..math.ndarray import to_list
 

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -629,3 +629,37 @@ def test_field_fn():
     m1 = MMDoc()
     m2 = MMDoc(Document(m1))
     assert m1 == m2
+
+
+def _serialize_deserialize(doc, serialization_type):
+    if serialization_type == 'protobuf':
+        return Document.from_protobuf(doc.to_protobuf())
+    if serialization_type == 'pickle':
+        return Document.from_bytes(doc.to_bytes())
+    if serialization_type == 'json':
+        return Document.from_json(doc.to_json())
+    if serialization_type == 'dict':
+        return Document.from_dict(doc.to_dict())
+    if serialization_type == 'base64':
+        return Document.from_base64(doc.to_base64())
+    return doc
+
+
+@pytest.mark.parametrize(
+    'serialization', [None, 'protobuf', 'pickle', 'json', 'dict', 'base64']
+)
+def test_multimodal_serialize_deserialize(serialization):
+    @dataclass
+    class MMDocument:
+        text: Text
+
+    mm = MMDocument(
+        text='hello world',
+    )
+
+    doc = Document(mm)
+    assert doc._metadata
+    assert doc.is_multimodal
+    doc = _serialize_deserialize(doc, serialization)
+    assert doc._metadata
+    assert doc.is_multimodal

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -660,6 +660,8 @@ def test_multimodal_serialize_deserialize(serialization):
     doc = Document(mm)
     assert doc._metadata
     assert doc.is_multimodal
+    _metadata_before = doc._metadata
     doc = _serialize_deserialize(doc, serialization)
     assert doc._metadata
     assert doc.is_multimodal
+    assert _metadata_before == doc._metadata


### PR DESCRIPTION
This bug is the root cause of multi-modal documents not working after being (de)serilaized from/to json or dict.
Details here: https://github.com/jina-ai/docarray/issues/429

Better multi-modal support (https://github.com/jina-ai/docarray/pull/425) partially depends on this.

There seems to be no super elegant way of solving this with pydantic, based on [this](https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes) and [this](https://github.com/samuelcolvin/pydantic/issues/655).

I see two options:
1. make metadata public, so rename `_metadata` -> `metadata`
2. set and validate `_metadata` manually

In order not to change the pydantic model of `Document`, this PR implements option 2.
