### PR TITLE
fix: proper setting of multimodal attributes

### DIFF
--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -106,7 +106,13 @@ class MultiModalMixin:
         if attr not in self._metadata['multi_modal_schema']:
             raise ValueError(f'the Document schema does not contain attribute {attr}')
 
-        return int(self._metadata['multi_modal_schema'][attr].get('position'))
+        pos = self._metadata['multi_modal_schema'][attr].get('position')
+        if pos is None:
+            raise ValueError(
+                f'attribute {attr} is not a valid multi modal attribute.'
+                f' One possible cause is the usage of a non-supported type in the dataclass definition.'
+            )
+        return int(pos)
 
     def get_multi_modal_attribute(self, attribute: str) -> 'DocumentArray':
         from docarray import DocumentArray

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -805,7 +805,6 @@ def test_set_multimodal_nested(serialization, nested_mmdoc):
     d.other_doc_list[0].heading.text = '0 new text list'
     d.other_doc_list[1].heading = new_inner_list_doc
 
-    print(d.other_doc.heading)
     assert d.other_doc.heading.text == 'new text inner doc'
     assert d.other_doc.heading in d.other_doc.chunks
     heading_in_chunk_of_chunks = False


### PR DESCRIPTION
Previously, setting a multi-modal attribute did not set chunks properly. This resulted in only Document level access working, while DocumentArray level access was broken.
This PR fixes this.

The previous tests were not comprehensive enough to catch this flaw. This PR adds tests to that effect.
