### PR TITLE
poc: parametrized image type

### DIFF
--- a/docarray/dataclasses/setter.py
+++ b/docarray/dataclasses/setter.py
@@ -27,6 +27,27 @@ def image_setter(value) -> 'Document':
     return doc
 
 
+def image_setter_(width, height, channel_axis, value) -> 'Document':
+    from docarray import Document
+
+    doc = Document(modality='image')
+
+    if isinstance(value, str):
+        doc.uri = value
+        doc._metadata['image_type'] = 'uri'
+        doc.load_uri_to_image_tensor(width, height, channel_axis)
+    elif isinstance(value, np.ndarray):
+        doc.tensor = value
+        doc._metadata['image_type'] = 'ndarray'
+    else:
+        from PIL.Image import Image
+
+        if isinstance(value, Image):
+            doc.tensor = np.array(value)
+            doc._metadata['image_type'] = 'PIL'
+    return doc
+
+
 def text_setter(value) -> 'Document':
     from docarray import Document
 

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -79,9 +79,28 @@ class MultiModalMixin:
                         }
                         root.chunks.append(chunk)
                 else:
-                    raise TypeError(
-                        f'Unsupported type annotation on field `{field.type._name}`'
-                    )
+                    # this is obviously not generally correct logic here
+                    # and also f*cking ugly, equally as obviuosly
+                    # so this is just to make the POC work
+                    import sys
+
+                    if sys.version_info >= (3, 9):
+                        from typing import get_type_hints, get_args
+                    else:
+                        from typing_extensions import get_type_hints, get_args
+
+                    main_type = get_args(field.type)[0]
+                    doc, attribute_type = cls._from_obj(attribute, field.type, field)
+                    multi_modal_schema[key] = {
+                        'attribute_type': attribute_type,
+                        'type': main_type.__name__,
+                        'position': len(root.chunks),
+                    }
+                    root.chunks.append(doc)
+                # else:
+                #     raise TypeError(
+                #         f'Unsupported type annotation on field `{field.type._name}`'
+                #     )
             else:
                 doc, attribute_type = cls._from_obj(attribute, field.type, field)
                 multi_modal_schema[key] = {

--- a/docarray/typing/__init__.py
+++ b/docarray/typing/__init__.py
@@ -12,6 +12,13 @@ from typing import (
     ForwardRef,
 )
 
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 if TYPE_CHECKING:
     import scipy.sparse
     import tensorflow
@@ -65,12 +72,28 @@ if TYPE_CHECKING:
     ]
 
 
-Image = TypeVar(
-    'Image',
-    str,
-    ForwardRef('np.ndarray'),
-    ForwardRef('PILImage'),
-)
+class Image:
+    def __class_getitem__(cls, item):
+        if isinstance(item, tuple):
+            if len(item) == 2:
+                width, height, axis = *item, -1
+            elif len(item) == 3:
+                width, height, axis = item
+            else:
+                raise ValueError('Invalid inputs for Image type')
+        elif isinstance(item, int):
+            width, height, axis = item, None, -1
+        else:
+            raise ValueError('Invalid inputs for Image type')
+        return Annotated[Image, width, height, axis]
+
+
+# Image = TypeVar(
+#     'Image',
+#     str,
+#     ForwardRef('np.ndarray'),
+#     ForwardRef('PILImage'),
+# )
 Text = TypeVar('Text', bound=str)
 Audio = TypeVar('Audio', str, ForwardRef('np.ndarray'))
 Video = TypeVar('Video', str, ForwardRef('np.ndarray'))


### PR DESCRIPTION
This **proof of concept** shows how we can make our dataclass types more flexible, for example by allowing the user to set the desired Image size right there.

This POC make the following possible:

```python
from docarray import dataclass, Document
from docarray.typing import Image, Text


@dataclass
class MMDoc:
    default_img: Image
    small_img: Image[10, 10]  # set image size
    large_img: Image[1000, 1000, 1]  # set size and channel axis


d = Document(MMDoc(default_img='testflow.jpg', small_img='testflow.jpg', large_img='testflow.jpg'))

print(d.default_img.tensor.shape)
print(d.small_img.tensor.shape)
print(d.large_img.tensor.shape)

>>> (50, 215, 3)
>>> (10, 10, 3)
>>> (1000, 3, 1000)
```
