### PR TITLE
feat: add root_id

### DIFF
--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -30,7 +30,7 @@ default_values = dict(
     chunks='ChunkArray',
     matches='MatchArray',
     timestamps=dict,
-    root_id='self.id',
+    root_id='__self_id__',
 )
 
 _all_mime_types = set(mimetypes.types_map.values())
@@ -115,7 +115,7 @@ class DocumentData:
                     from docarray.score import NamedScore
 
                     setattr(self, key, defaultdict(NamedScore))
-                elif v == 'self.id':
+                elif v == '__self_id__':
                     setattr(self, key, self.id)
                 else:
                     setattr(self, key, v() if callable(v) else v)

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -30,6 +30,7 @@ default_values = dict(
     chunks='ChunkArray',
     matches='MatchArray',
     timestamps=dict,
+    root_id='self.id',
 )
 
 _all_mime_types = set(mimetypes.types_map.values())
@@ -61,6 +62,7 @@ class DocumentData:
     scores: Optional[Dict[str, Union['NamedScore', Dict]]] = None
     chunks: Optional['DocumentArray'] = None
     matches: Optional['DocumentArray'] = None
+    root_id: Optional[str] = None
 
     @property
     def _non_empty_fields(self) -> Tuple[str]:
@@ -113,6 +115,8 @@ class DocumentData:
                     from docarray.score import NamedScore
 
                     setattr(self, key, defaultdict(NamedScore))
+                elif v == 'self.id':
+                    setattr(self, key, self.id)
                 else:
                     setattr(self, key, v() if callable(v) else v)
 

--- a/docarray/document/mixins/_property.py
+++ b/docarray/document/mixins/_property.py
@@ -29,6 +29,15 @@ class _PropertyMixin:
         self._data.parent_id = value
 
     @property
+    def root_id(self) -> Optional[str]:
+        self._data._set_default_value_if_none('root_id')
+        return self._data.root_id
+
+    @root_id.setter
+    def root_id(self, value: str):
+        self._data.root_id = value
+
+    @property
     def granularity(self) -> Optional[int]:
         self._data._set_default_value_if_none('granularity')
         return self._data.granularity


### PR DESCRIPTION
*Goals:**

This adds `.root_id` to `Document`.
`.root_id` is similar to `.parent_id`, but points _all the way to the top_, instead of just one chunk-level above.

This is particularly useful in combination with [secondary indices](https://github.com/jina-ai/docarray/pull/456), to tie a search back to the top-level document:

```python
best_match = da.find(query=..., secondary_index='@ccc'][0]  # best_match is a chunk of a chunk of a chunk
match_top_level = da[best_match.root_id]  # get top level document
``` 

**Caution**
this is a breaking change, since it changed the protobuf definition