### PR TITLE
fix: use os urandom to generate doc id

### DIFF
--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -1,5 +1,5 @@
 import mimetypes
-import random
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -38,9 +38,7 @@ _all_mime_types = set(mimetypes.types_map.values())
 @dataclass(unsafe_hash=True, eq=False)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
-    id: str = field(
-        default_factory=lambda: random.getrandbits(128).to_bytes(16, 'big').hex()
-    )
+    id: str = field(default_factory=lambda: os.urandom(16).hex())
     parent_id: Optional[str] = None
     granularity: Optional[int] = None
     adjacency: Optional[int] = None

--- a/tests/unit/array/mixins/test_io.py
+++ b/tests/unit/array/mixins/test_io.py
@@ -13,6 +13,7 @@ from docarray.array.storage.qdrant import QdrantConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 from docarray.array.elastic import DocumentArrayElastic, ElasticConfig
+from docarray.helper import random_identity
 from tests import random_docs
 
 
@@ -227,9 +228,11 @@ def test_push_pull_io(da_cls, config, show_progress, start_storage):
     random_texts = [str(uuid.uuid1()) for _ in da1]
     da1[:, 'text'] = random_texts
 
-    da1.push('myda', show_progress=show_progress)
+    name = random_identity()
 
-    da2 = da_cls.pull('myda', show_progress=show_progress, config=config())
+    da1.push(name, show_progress=show_progress)
+
+    da2 = da_cls.pull(name, show_progress=show_progress, config=config())
 
     assert len(da1) == len(da2) == 10
     assert da1.texts == da2.texts == random_texts

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 from docarray import DocumentArray
 from docarray.array.mixins.io.pushpull import JINA_CLOUD_CONFIG
+from docarray.helper import random_identity
 
 from tests import random_docs
 
@@ -79,7 +80,8 @@ def test_push(mocker, monkeypatch):
     _mock_post(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name')
+    name = random_identity()
+    docs.push(name)
 
     assert mock.call_count == 1
 
@@ -90,7 +92,8 @@ def test_push_with_public(mocker, monkeypatch, public):
     _mock_post(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name', public=public)
+    name = random_identity()
+    docs.push(name, public=public)
 
     _, mock_kwargs = mock.call_args_list[0]
 
@@ -145,8 +148,9 @@ def test_api_url_change(mocker, monkeypatch):
     _mock_get(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name')
-    docs.pull(name='test_name')
+    name = random_identity()
+    docs.push(name)
+    docs.pull(name)
 
     del os.environ['JINA_HUBBLE_REGISTRY']
     _get_cloud_api.cache_clear()
@@ -177,8 +181,9 @@ def test_api_authorization_header_from_config(mocker, monkeypatch, tmpdir):
     _mock_get(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name')
-    DocumentArray.pull(name='test_name')
+    name = random_identity()
+    docs.push(name)
+    DocumentArray.pull(name)
 
     del os.environ['JINA_HUB_ROOT']
 
@@ -208,8 +213,9 @@ def test_api_authorization_header_from_env(mocker, monkeypatch, set_env_vars):
     _mock_get(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name')
-    DocumentArray.pull(name='test_name')
+    name = random_identity()
+    docs.push(name)
+    DocumentArray.pull(name)
 
     _get_hub_config.cache_clear()
     _get_auth_token.cache_clear()
@@ -245,8 +251,9 @@ def test_api_authorization_header_env_and_config(
     _mock_get(mock, monkeypatch)
 
     docs = random_docs(2)
-    docs.push(name='test_name')
-    DocumentArray.pull(name='test_name')
+    name = random_identity()
+    docs.push(name)
+    DocumentArray.pull(name)
 
     del os.environ['JINA_HUB_ROOT']
 

--- a/tests/unit/document/test_docdata.py
+++ b/tests/unit/document/test_docdata.py
@@ -1,5 +1,8 @@
+import random
+
 import numpy as np
 import pytest
+import torch
 
 from docarray import Document, DocumentArray
 from docarray.array.chunk import ChunkArray
@@ -29,6 +32,21 @@ def test_doc_id_setter():
         id='d0',
     )
     assert d.id == d.chunks[0].parent_id == 'd0'
+
+
+def test_random_seed_no_effect_on_id():
+    da = DocumentArray()
+    for _ in range(10):
+        random.seed(0)
+        np.random.seed(0)
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+        da.append(
+            Document(
+                chunks=[Document()],
+            )
+        )
+    assert len(set(da[...][:, 'id'])) == 20
 
 
 def test_doc_hash_complicate_content():


### PR DESCRIPTION
replacing #462 

hi guys, there is a bug in docarray Document.id, it is affected by random.seed() , see the behavior here:

```python
import random
import numpy as np
from docarray import Document, DocumentArray

da = DocumentArray()

for _ in range(10):
    random.seed(0)
    np.random.seed(0)
    # now do some math stuff
    tensor = ...

    da.append(Document(tensor=tensor))

print(da[:, 'id'])
```
then you will find:
```
['e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd', 'e3e70682c2094cac629f6fbed82c07cd']

```

**Expected behavior:**
Doc ID should not be controlled by random.seed/numpy.seed/torch.seed etc.

**Unexpected behavior:**
Now every doc has the same id, this leads to many other problems in DocArray/push/pull/persist/all kinds of API. It is also the side-effect that user unexpected when using DocArray.

**Solution:**

use `os.urandom(16).hex()` for doc.id generation, a bit slower but faster than `uuid1` but it is independent from seed generation.

This bug is sneaky and very unexpected, which caused https://jina-ai.slack.com/archives/C0169V26ATY/p1658429345447309

In general, the current design of ID generation is a flaw as it was not put into computational-intensive/real numerical application.