### PR TITLE
fix(elastic): handle bulk operation error info for another op type

### DIFF
--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -158,13 +158,13 @@ class BackendMixin(BaseBackendMixin):
         client.indices.refresh(index=self._config.index_name)
         return client
 
-    def _send_requests(self, request):
-        failed_index = []
+    def _send_requests(self, request) -> List[Dict]:
+        accumulated_info = []
         for success, info in parallel_bulk(self._client, request, raise_on_error=False):
             if not success:
-                failed_index.append(info['index'])
+                accumulated_info.append(info)
 
-        return failed_index
+        return accumulated_info
 
     def _refresh(self, index_name):
         self._client.indices.refresh(index=index_name)

--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -1,6 +1,7 @@
 import copy
 import uuid
 from dataclasses import dataclass, field
+import warnings
 from typing import (
     Dict,
     Optional,
@@ -159,9 +160,12 @@ class BackendMixin(BaseBackendMixin):
         return client
 
     def _send_requests(self, request) -> List[Dict]:
+        """Send bulk request to Elastic and gather the successful info"""
         accumulated_info = []
         for success, info in parallel_bulk(self._client, request, raise_on_error=False):
             if not success:
+                warnings.warn(str(info))
+            else:
                 accumulated_info.append(info)
 
         return accumulated_info

--- a/docarray/array/storage/elastic/seqlike.py
+++ b/docarray/array/storage/elastic/seqlike.py
@@ -69,7 +69,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
         return failed_index_ids
 
-    def _upload_batch(self, docs: Iterable['Document']):
+    def _upload_batch(self, docs: Iterable['Document']) -> List[int]:
         batch = []
         accumulated_info = []
         for doc in docs:

--- a/tests/unit/array/storage/elastic/test_add.py
+++ b/tests/unit/array/storage/elastic/test_add.py
@@ -3,6 +3,7 @@ from docarray import Document, DocumentArray
 import pytest
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')
 def test_add_ignore_existing_doc_id(start_storage):
     elastic_doc = DocumentArray(
         storage='elasticsearch',
@@ -45,6 +46,7 @@ def test_add_ignore_existing_doc_id(start_storage):
     assert len(elastic_doc[:, 'embedding']) == 7
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')
 def test_add_skip_wrong_data_type_and_fix_offset(start_storage):
     elastic_doc = DocumentArray(
         storage='elasticsearch',

--- a/tests/unit/array/storage/elastic/test_del.py
+++ b/tests/unit/array/storage/elastic/test_del.py
@@ -2,6 +2,7 @@ from docarray import Document, DocumentArray
 import pytest
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')
 @pytest.mark.parametrize('deleted_elmnts', [[0, 1], ['r0', 'r1']])
 def test_delete_offset_success_sync_es_offset_index(deleted_elmnts, start_storage):
     elastic_doc = DocumentArray(
@@ -49,6 +50,7 @@ def test_delete_offset_success_sync_es_offset_index(deleted_elmnts, start_storag
         assert actual_offset_index == expected_offset
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')
 def test_success_handle_bulk_delete_not_found(start_storage):
     elastic_doc = DocumentArray(
         storage='elasticsearch',


### PR DESCRIPTION
Previous Behavior

When delete operation performed  and error occured it will throw these error 

```bash
2022-08-01T19:48:11.223520457Z self._update_offset2ids_meta()
2022-08-01T19:48:11.223527216Z File "/opt/pysetup/.venv/lib/python3.8/site-packages/docarray/array/storage/elastic/backend.py", line 203, in _update_offset2ids_meta
2022-08-01T19:48:11.223553779Z self._send_requests(requests)
2022-08-01T19:48:11.223567841Z File "/opt/pysetup/.venv/lib/python3.8/site-packages/docarray/array/storage/elastic/backend.py", line 165, in _send_requests
2022-08-01T19:48:11.223575146Z failed_index.append(info['index'])
2022-08-01T19:48:11.223581640Z KeyError: 'index'
```

This because it directly parse `'index'` key from the bulk info inside `_send_requests` function

Goals:

- handle the error info from elastic search bulk requests if the operation return error from `_op_type` other than `index` e.g. `delete`
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
