### PR TITLE
refactor: remove lru_cache decorator from _get_auth_token

### DIFF
--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -27,7 +27,6 @@ def _get_hub_config() -> Optional[Dict]:
             return json.load(f)
 
 
-@lru_cache()
 def _get_auth_token() -> Optional[str]:
     hub_config = _get_hub_config()
     config_auth_token = hub_config.get('auth_token') if hub_config else None

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -165,10 +165,9 @@ def test_api_url_change(mocker, monkeypatch):
 
 
 def test_api_authorization_header_from_config(mocker, monkeypatch, tmpdir):
-    from docarray.array.mixins.io.pushpull import _get_hub_config, _get_auth_token
+    from docarray.array.mixins.io.pushpull import _get_hub_config
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     os.environ['JINA_HUB_ROOT'] = str(tmpdir)
 
@@ -188,7 +187,6 @@ def test_api_authorization_header_from_config(mocker, monkeypatch, tmpdir):
     del os.environ['JINA_HUB_ROOT']
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     assert mock.call_count == 3  # 1 for push, 1 for pull, 1 for download
 
@@ -203,10 +201,9 @@ def test_api_authorization_header_from_config(mocker, monkeypatch, tmpdir):
     'set_env_vars', [{'JINA_AUTH_TOKEN': 'test-auth-token'}], indirect=True
 )
 def test_api_authorization_header_from_env(mocker, monkeypatch, set_env_vars):
-    from docarray.array.mixins.io.pushpull import _get_hub_config, _get_auth_token
+    from docarray.array.mixins.io.pushpull import _get_hub_config
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     mock = mocker.Mock()
     _mock_post(mock, monkeypatch)
@@ -218,7 +215,6 @@ def test_api_authorization_header_from_env(mocker, monkeypatch, set_env_vars):
     DocumentArray.pull(name)
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     assert mock.call_count == 3  # 1 for push, 1 for pull, 1 for download
 
@@ -235,10 +231,9 @@ def test_api_authorization_header_from_env(mocker, monkeypatch, set_env_vars):
 def test_api_authorization_header_env_and_config(
     mocker, monkeypatch, tmpdir, set_env_vars
 ):
-    from docarray.array.mixins.io.pushpull import _get_hub_config, _get_auth_token
+    from docarray.array.mixins.io.pushpull import _get_hub_config
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     os.environ['JINA_HUB_ROOT'] = str(tmpdir)
 
@@ -258,7 +253,6 @@ def test_api_authorization_header_env_and_config(
     del os.environ['JINA_HUB_ROOT']
 
     _get_hub_config.cache_clear()
-    _get_auth_token.cache_clear()
 
     assert mock.call_count == 3  # 1 for push, 1 for pull, 1 for download
 


### PR DESCRIPTION
Goals:
When a user logout and login again, the `_get_auth_token` function still returns the old authentification token which is not valid anymore due to the lru_cache.  To prevent this unwanted behavior, I suggest to remove the lru_cache decorator. Moreover, I think the cache is not very useful for the `_get_auth_token` function, since sending a request to hubble is usually much more time-consuming than reading the authentification token.
 
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
