### PR TITLE
feat(elastic): add find kwargs for perf tuning

### DIFF
--- a/docarray/array/storage/elastic/find.py
+++ b/docarray/array/storage/elastic/find.py
@@ -34,7 +34,11 @@ if TYPE_CHECKING:
 
 class FindMixin(BaseFindMixin):
     def _find_similar_vectors(
-        self, query: 'ElasticArrayType', filter: Optional[Dict] = None, limit=10
+        self,
+        query: 'ElasticArrayType',
+        filter: Optional[Dict] = None,
+        limit=10,
+        **kwargs,
     ):
         """
         Return vector search results for the input query. `script_score` will be used in filter_field is set.
@@ -50,14 +54,18 @@ class FindMixin(BaseFindMixin):
         if is_all_zero:
             query = query + EPSILON
 
+        knn_query = {
+            'field': 'embedding',
+            'query_vector': query,
+            'k': limit,
+            'num_candidates': 10000
+            if 'num_candidates' not in kwargs
+            else kwargs['num_candidates'],
+        }
+
         resp = self._client.knn_search(
             index=self._config.index_name,
-            knn={
-                'field': 'embedding',
-                'query_vector': query,
-                'k': limit,
-                'num_candidates': 10000,
-            },
+            knn=knn_query,
             filter=filter,
         )
         list_of_hits = resp['hits']['hits']
@@ -133,7 +141,8 @@ class FindMixin(BaseFindMixin):
             query = query.reshape((num_rows, -1))
 
         return [
-            self._find_similar_vectors(q, filter=filter, limit=limit) for q in query
+            self._find_similar_vectors(q, filter=filter, limit=limit, **kwargs)
+            for q in query
         ]
 
     def _find_with_filter(self, query: Dict, limit: Optional[Union[int, float]] = 20):

--- a/docs/advanced/document-store/elasticsearch.md
+++ b/docs/advanced/document-store/elasticsearch.md
@@ -219,7 +219,7 @@ Embeddings Nearest Neighbours with "price" at most 7:
  embedding=[4. 4. 4.],  price=4
  ```
 
-Additionally you can tune the approximate kNN for speed or accuracy by providing `num_candidates` kwargs when calling the `find` method
+Additionally you can tune the approximate kNN for speed or accuracy by providing `num_candidates` kwarg when calling the `find` method:
 
 ```python
 results = da.find(np_query, filter=filter, limit=n_limit, num_candidates=100)

--- a/docs/advanced/document-store/elasticsearch.md
+++ b/docs/advanced/document-store/elasticsearch.md
@@ -219,6 +219,16 @@ Embeddings Nearest Neighbours with "price" at most 7:
  embedding=[4. 4. 4.],  price=4
  ```
 
+Additionally you can tune the approximate kNN for speed or accuracy by providing `num_candidates` kwargs when calling the `find` method
+
+```python
+results = da.find(np_query, filter=filter, limit=n_limit, num_candidates=100)
+```
+
+```{tip}
+You can read more about approximate kNN tuning [here](https://www.elastic.co/guide/en/elasticsearch/reference/master/knn-search.html#tune-approximate-knn-for-speed-accuracy)
+```
+
 ### Search by filter query
 
 One can search with user-defined query filters using the `.find` method. Such queries can be constructed following the

--- a/tests/unit/array/storage/elastic/test_find.py
+++ b/tests/unit/array/storage/elastic/test_find.py
@@ -1,0 +1,35 @@
+from docarray import Document, DocumentArray
+import numpy as np
+
+
+def test_success_find_with_added_kwargs(start_storage, monkeypatch):
+    nrof_docs = 1000
+    num_candidates = 100
+
+    elastic_doc = DocumentArray(
+        storage='elasticsearch',
+        config={
+            'n_dim': 3,
+            'distance': 'l2_norm',
+            'index_name': 'test_success_find_with_added_kwargs',
+        },
+    )
+
+    with elastic_doc:
+        elastic_doc.extend(
+            [
+                Document(id=f'r{i}', embedding=np.ones((3,)) * i)
+                for i in range(nrof_docs)
+            ],
+        )
+
+    def _mock_knn_search(**kwargs):
+        assert kwargs['knn']['num_candidates'] == num_candidates
+
+        return {'hits': {'hits': []}}
+
+    monkeypatch.setattr(elastic_doc._client, 'knn_search', _mock_knn_search)
+
+    np_query = np.array([2, 1, 3])
+
+    elastic_doc.find(np_query, limit=10, num_candidates=num_candidates)


### PR DESCRIPTION
Goals:

- Enable Elastic Search knn search performance tuning by configure `num_candidates` param during `find` method call
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
