### PR TITLE
fix(find): fix misleading signature of _find_by_text

### DIFF
--- a/docarray/array/mixins/find.py
+++ b/docarray/array/mixins/find.py
@@ -299,5 +299,7 @@ class FindMixin:
         else:
             return self
 
-    def _find_by_text(self, query: Union[str, List[str]], index: str = 'text'):
-        raise NotImplementedError('Search by text is not supported')
+    def _find_by_text(self, *args, **kwargs):
+        raise NotImplementedError(
+            f'Search by text is not supported with this backend {self.__class__.__name__}'
+        )


### PR DESCRIPTION
```python
from docarray import Document, DocumentArray

d = Document(uri='https://www.gutenberg.org/files/1342/1342-0.txt').load_uri_to_text()
da = DocumentArray(Document(text=s.strip()) for s in d.text.split('\n') if s.strip())
print(da.find('hello'))
```

Before:

```
Traceback (most recent call last):
  File "/Users/hanxiao/Documents/jina/toy43.py", line 5, in <module>
    print(da.find('hello'))
  File "/Users/hanxiao/Documents/docarray/docarray/array/mixins/find.py", line 168, in find
    result = self._find_by_text(query, index=index, limit=limit, **kwargs)
TypeError: _find_by_text() got an unexpected keyword argument 'limit'
```

After:

```
Traceback (most recent call last):
  File "/Users/hanxiao/Documents/jina/toy43.py", line 5, in <module>
    print(da.find('hello'))
  File "/Users/hanxiao/Documents/docarray/docarray/array/mixins/find.py", line 168, in find
    result = self._find_by_text(query, index=index, limit=limit, **kwargs)
  File "/Users/hanxiao/Documents/docarray/docarray/array/mixins/find.py", line 303, in _find_by_text
    raise NotImplementedError(f'Search by text is not supported with this backend {self.__class__.__name__}')
NotImplementedError: Search by text is not supported with this backend DocumentArrayInMemory

Process finished with exit code 1

```

