### PR TITLE
fix: update offset2id when deleting in subindex

### DIFF
--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -146,7 +146,7 @@ class BaseGetSetDelMixin(ABC):
         if getattr(self, '_subindices', None):
             for selector, da in self._subindices.items():
                 ids_subindex = DocumentArray(self[ids])[selector, 'id']
-                da._del_docs_by_ids(ids_subindex)
+                da._del_docs(ids_subindex)
 
     def _del_docs(self, ids):
         self._del_docs_by_ids(ids)

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -146,7 +146,7 @@ class BaseGetSetDelMixin(ABC):
         if getattr(self, '_subindices', None):
             for selector, da in self._subindices.items():
                 ids_subindex = DocumentArray(self[ids])[selector, 'id']
-                da._del_docs(ids_subindex)
+                del da[ids_subindex]
 
     def _del_docs(self, ids):
         self._del_docs_by_ids(ids)


### PR DESCRIPTION
Goals:

make sure that `offset2ids` is correctly updated when deleting in a subindex.
Previously, the call to `del_docs_by_ids()` did not do it, but using `del` does it under the hood.