### PR TITLE
docs: bump es version in documentation to match the tests

### DIFF
--- a/docs/advanced/document-store/elasticsearch.md
+++ b/docs/advanced/document-store/elasticsearch.md
@@ -18,7 +18,7 @@ To use Elasticsearch as the storage backend, it is required to have the Elastics
 version: "3.3"
 services:
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
     environment:
       - xpack.security.enabled=false
       - discovery.type=single-node


### PR DESCRIPTION
# Context
A user report that a part of the [documentation](https://docarray.jina.ai/advanced/document-store/elasticsearch/#start-elastic-service) was not working. The issue was that the es version that we show in the docs is not up to date.

# What this pr do

bump the es version in the docs
