### PR TITLE
fix(plot): be robust against non-existing subindices

### DIFF
--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -79,7 +79,7 @@ class PlotMixin:
         is_multimodal = all(d.is_multimodal for d in self)
         table.add_row('Multimodal dataclass', str(is_multimodal))
 
-        if getattr(self, '_subindices'):
+        if getattr(self, '_subindices', None):
             table.add_row(
                 'Subindices', rich.markup.escape(str(tuple(self._subindices.keys())))
             )


### PR DESCRIPTION
Sometimes `.plot()` can be called when `._subindices` does not yet exist, resulting in an error.

This fix makes a check about the existence of subindices robust against that problem.
