### PR TITLE
fix: annlite offsetmapping

### DIFF
--- a/docarray/array/storage/annlite/getsetdel.py
+++ b/docarray/array/storage/annlite/getsetdel.py
@@ -42,6 +42,15 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _del_docs_by_ids(self, ids):
         self._annlite.delete(ids)
 
+    def __del__(self) -> None:
+        if not self._persist:
+            self._offset2ids.clear()
+            self._annlite.clear()
+
+        self._annlite.close()
+
+        super().__del__()
+
     def _load_offset2ids(self):
         self._offsetmapping = OffsetMapping(
             data_path=self._config.data_path, in_memory=False

--- a/docarray/array/storage/annlite/helper.py
+++ b/docarray/array/storage/annlite/helper.py
@@ -11,7 +11,7 @@ class OffsetMapping(Table):
         data_path: Optional[Path] = None,
         in_memory: bool = True,
     ):
-        super().__init__(name, data_path, in_memory)
+        super().__init__(name, data_path, in_memory=in_memory)
         self.create_table()
         self._size = None
 

--- a/docarray/array/storage/annlite/seqlike.py
+++ b/docarray/array/storage/annlite/seqlike.py
@@ -24,11 +24,6 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     def append(self, value: 'Document'):
         self.extend([value])
 
-    def __del__(self) -> None:
-        if not self._persist:
-            self._offset2ids.clear()
-            self._annlite.clear()
-
     def __eq__(self, other):
         """In annlite backend, data are considered as identical if configs point to the same database source"""
         return (


### PR DESCRIPTION
Goals:

-  1. fix the offsetmapping in annlite, (`in_memory=False`)
-  2. `__del__` should be placed in `getsetdel.py`
-  3. should close lmdb cursor in `__del__` so that lmdb can be reused in another annlite instance

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
