### PR TITLE
Change journal mode to WAL

### DIFF
--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -33,7 +33,7 @@ class SqliteConfig:
     table_name: Optional[str] = None
     serialize_config: Dict = field(default_factory=dict)
     conn_config: Dict = field(default_factory=dict)
-    journal_mode: str = 'DELETE'
+    journal_mode: str = 'WAL'
     synchronous: str = 'OFF'
 
 


### PR DESCRIPTION
THE `WAL` mode is mush faster then `DELETE` mode for the sqlite.

Goals:

- speed up the sqlite backend
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
