### PR TITLE
docs: push pull use pip install common

### DIFF
--- a/docs/fundamentals/documentarray/serialization.md
+++ b/docs/fundamentals/documentarray/serialization.md
@@ -26,7 +26,7 @@ If you are building a webservice and want to use JSON for passing DocArray objec
 ```
 
 ```{important}
-Depending on which protocol you use, this feature requires `pydantic` or `protobuf` dependency. You can do `pip install "docarray[full]"` to install it.
+Depending on which protocol you use, this feature requires `pydantic` or `protobuf` dependency. You can do `pip install "docarray[common]"` to install it.
 ```
 
 


### PR DESCRIPTION
# Context

to use serialization one need ton install docarray common. The docs said full which is not needed