### PR TITLE
feat: allow choose to display from tensor or from uri in document

### DIFF
--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -71,36 +71,47 @@ class PlotMixin:
         return tree
 
     def display(self):
-        """Plot image data from :attr:`.tensor` or :attr:`.uri`."""
+        """Plot image data from :attr:`.uri` or from :attr:`.tensor` if :attr:`.uri` is empty ."""
         from IPython.display import Image, display
 
         if self.uri:
-            if self.mime_type.startswith('audio') or self.uri.startswith('data:audio/'):
-                uri = _convert_display_uri(self.uri, self.mime_type)
-                _html5_audio_player(uri)
-            elif self.mime_type.startswith('video') or self.uri.startswith(
-                'data:video/'
-            ):
-                uri = _convert_display_uri(self.uri, self.mime_type)
-                _html5_video_player(uri)
-            elif self.uri.startswith('data:image/'):
-                _html5_image(self.uri)
-            else:
-                display(Image(self.uri))
+            self.display_uri()
         elif self.tensor is not None:
-            try:
-                import PIL.Image
-
-                p = PIL.Image.fromarray(self.tensor)
-                if p.mode != 'RGB':
-                    raise
-                display(p)
-            except:
-                import matplotlib.pyplot as plt
-
-                plt.matshow(self.tensor)
+            self.display_tensor()
         else:
             self.summary()
+
+    def display_tensor(self):
+        """Plot image data from :attr:`.tensor`"""
+        from IPython.display import display
+
+        try:
+            import PIL.Image
+
+            p = PIL.Image.fromarray(self.tensor)
+            if p.mode != 'RGB':
+                raise
+            display(p)
+        except:
+            import matplotlib.pyplot as plt
+
+            plt.matshow(self.tensor)
+
+    def display_uri(self):
+        """Plot image data from :attr:`.uri`"""
+
+        from IPython.display import Image, display
+
+        if self.mime_type.startswith('audio') or self.uri.startswith('data:audio/'):
+            uri = _convert_display_uri(self.uri, self.mime_type)
+            _html5_audio_player(uri)
+        elif self.mime_type.startswith('video') or self.uri.startswith('data:video/'):
+            uri = _convert_display_uri(self.uri, self.mime_type)
+            _html5_video_player(uri)
+        elif self.uri.startswith('data:image/'):
+            _html5_image(self.uri)
+        else:
+            display(Image(self.uri))
 
     def plot_matches_sprites(
         self,

--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -70,19 +70,35 @@ class PlotMixin:
                     d._plot_recursion(_match_tree)
         return tree
 
-    def display(self):
-        """Plot image data from :attr:`.uri` or from :attr:`.tensor` if :attr:`.uri` is empty ."""
-        from IPython.display import Image, display
+    def display(self, from_: Optional[str] = None):
+        """
+        Plot image data from :attr:`.uri` or from :attr:`.tensor` if :attr:`.uri` is empty .
 
-        if self.uri:
+        :param from_: an optional string to decide if a document should display using either the uri or the tensor field.
+        """
+
+        if not from_:
+            if self.uri:
+                from_ = 'uri'
+            elif self.tensor is not None:
+                from_ = 'tensor'
+            else:
+                self.summary()
+
+        if from_ == 'uri':
             self.display_uri()
-        elif self.tensor is not None:
+        elif from_ == 'tensor':
             self.display_tensor()
         else:
             self.summary()
 
     def display_tensor(self):
         """Plot image data from :attr:`.tensor`"""
+        if not self.tensor:
+            raise ValueError(
+                'Impossible to display with tensor when the tensor is None'
+            )
+
         from IPython.display import display
 
         try:
@@ -99,6 +115,9 @@ class PlotMixin:
 
     def display_uri(self):
         """Plot image data from :attr:`.uri`"""
+
+        if not self.uri:
+            raise ValueError('Impossible to display with uri when the uri is None')
 
         from IPython.display import Image, display
 

--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -94,7 +94,7 @@ class PlotMixin:
 
     def display_tensor(self):
         """Plot image data from :attr:`.tensor`"""
-        if not self.tensor:
+        if self.tensor is None:
             raise ValueError(
                 'Impossible to display with tensor when the tensor is None'
             )

--- a/tests/unit/document/test_summary.py
+++ b/tests/unit/document/test_summary.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 
 from docarray import Document
 
@@ -24,11 +25,25 @@ def test_single_doc_summary():
 def test_plot_image():
     d = Document(uri=os.path.join(cur_dir, 'toydata/test.png'))
     d.display()
+    d.display(from_='uri')
 
     d.load_uri_to_image_tensor()
     d.uri = None
 
     d.display()
+    d.display(from_='tensor')
+
+
+def test_plot_image_wrong():
+    d = Document(uri=os.path.join(cur_dir, 'toydata/test.png'))
+    with pytest.raises(ValueError):
+        d.display(from_='tensor')
+
+    d.load_uri_to_image_tensor()
+    d.uri = None
+
+    with pytest.raises(ValueError):
+        d.display(from_='uri')
 
 
 def test_plot_audio():


### PR DESCRIPTION
# context

This pr refactor the code so that we can chose if we want to display from uri or from tensor ( issue https://github.com/jina-ai/docarray/issues/517)

Now you can do

```python
from docarray import Document

d = Document(uri=os.path.join(cur_dir, 'toydata/test.png'))
d.display()
d.display(from_='uri')

d.load_uri_to_image_tensor()
d.uri = None

d.display()
d.display(from_='tensor')
```