### PR TITLE
perf: only check if field is set

### DIFF
--- a/docarray/array/queryset/lookup.py
+++ b/docarray/array/queryset/lookup.py
@@ -28,6 +28,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from typing import TYPE_CHECKING
 
+from docarray.document.data import _is_not_empty
+
 if TYPE_CHECKING:
     from docarray import Document
 import re
@@ -121,7 +123,7 @@ def lookup(key, val, doc: 'Document') -> bool:
 
             return is_empty != val
         else:
-            return (get_key in doc.non_empty_fields) == val
+            return (_is_not_empty(get_key, value)) == val
     else:
         # return value == val
         raise ValueError(

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -35,6 +35,26 @@ default_values = dict(
 _all_mime_types = set(mimetypes.types_map.values())
 
 
+def _is_not_empty(attribute, value):
+    if attribute not in default_values:
+        return True
+    else:
+        dv = default_values[attribute]
+        if dv in (
+            'ChunkArray',
+            'MatchArray',
+            'DocumentArray',
+            list,
+            dict,
+            'Dict[str, NamedScore]',
+        ):
+            if value:
+                return True
+        elif value != dv:
+            return True
+    return False
+
+
 @dataclass(unsafe_hash=True, eq=False)
 class DocumentData:
     _reference_doc: 'Document' = field(hash=False, compare=False)
@@ -68,22 +88,8 @@ class DocumentData:
             if not f_name.startswith('_') or f_name == '_metadata':
                 v = getattr(self, f_name)
                 if v is not None:
-                    if f_name not in default_values:
+                    if _is_not_empty(f_name, v):
                         r.append(f_name)
-                    else:
-                        dv = default_values[f_name]
-                        if dv in (
-                            'ChunkArray',
-                            'MatchArray',
-                            'DocumentArray',
-                            list,
-                            dict,
-                            'Dict[str, NamedScore]',
-                        ):
-                            if v:
-                                r.append(f_name)
-                        elif v != dv:
-                            r.append(f_name)
 
         return tuple(r)
 

--- a/docarray/document/data.py
+++ b/docarray/document/data.py
@@ -36,22 +36,23 @@ _all_mime_types = set(mimetypes.types_map.values())
 
 
 def _is_not_empty(attribute, value):
-    if attribute not in default_values:
-        return True
-    else:
-        dv = default_values[attribute]
-        if dv in (
-            'ChunkArray',
-            'MatchArray',
-            'DocumentArray',
-            list,
-            dict,
-            'Dict[str, NamedScore]',
-        ):
-            if value:
-                return True
-        elif value != dv:
+    if value is not None:
+        if attribute not in default_values:
             return True
+        else:
+            dv = default_values[attribute]
+            if dv in (
+                'ChunkArray',
+                'MatchArray',
+                'DocumentArray',
+                list,
+                dict,
+                'Dict[str, NamedScore]',
+            ):
+                if value:
+                    return True
+            elif value != dv:
+                return True
     return False
 
 
@@ -87,9 +88,8 @@ class DocumentData:
             f_name = f.name
             if not f_name.startswith('_') or f_name == '_metadata':
                 v = getattr(self, f_name)
-                if v is not None:
-                    if _is_not_empty(f_name, v):
-                        r.append(f_name)
+                if _is_not_empty(f_name, v):
+                    r.append(f_name)
 
         return tuple(r)
 


### PR DESCRIPTION
speed up the filter case described in https://github.com/jina-ai/docarray/issues/502#issuecomment-1235303756
code:
```python
import time
from docarray import DocumentArray, Document

num = 10_000
da = DocumentArray(Document(text='lsdkfjsl') for x in range(num)) + DocumentArray(Document(blob=b'lsdkfjsl') for x in range(num))

start = time.time()
print(len(da.find(query={'text': {'$exists': True}})))
print(f'time with find: {time.time() - start}')
```

main: 0.24
feat: 0.077

closes: https://github.com/jina-ai/internal-tasks/issues/426