### PR TITLE
fix: consider tuples may not be created from yaml

### DIFF
--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -150,7 +150,8 @@ class BackendMixin(BaseBackendMixin):
                     'index': True,
                 }
 
-        for col, coltype in self._config.columns:
+        for col_desc in self._config.columns:
+            col, coltype = tuple(col_desc)
             da_schema['mappings']['properties'][col] = {
                 'type': self._map_type(coltype),
                 'index': True,

--- a/docarray/array/storage/elastic/getsetdel.py
+++ b/docarray/array/storage/elastic/getsetdel.py
@@ -12,7 +12,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     MAX_ES_RETURNED_DOCS = 10000
 
     def _document_to_elastic(self, doc: 'Document') -> Dict:
-        extra_columns = {col: doc.tags.get(col) for col, _ in self._config.columns}
+        extra_columns = {col_desc[0]: doc.tags.get(col_desc[0]) for col_desc in self._config.columns}
         request = {
             '_op_type': 'index',
             '_id': doc.id,

--- a/docarray/array/storage/qdrant/getsetdel.py
+++ b/docarray/array/storage/qdrant/getsetdel.py
@@ -65,7 +65,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         )
 
     def _document_to_qdrant(self, doc: 'Document') -> 'PointStruct':
-        extra_columns = {col: doc.tags.get(col) for col, _ in self._config.columns}
+        extra_columns = {col_desc[0]: doc.tags.get(col_desc[0]) for col_desc in self._config.columns}
 
         return PointStruct(
             id=self._map_id(doc.id),

--- a/docarray/array/storage/redis/backend.py
+++ b/docarray/array/storage/redis/backend.py
@@ -146,7 +146,8 @@ class BackendMixin(BaseBackendMixin):
             index_param['INITIAL_CAP'] = self._config.initial_cap
         schema = [VectorField('embedding', self._config.method, index_param)]
 
-        for col, coltype in self._config.columns:
+        for col_desc in self._config.columns:
+            col, coltype = tuple(col_desc)
             schema.append(self._map_column(col, coltype))
 
         return schema

--- a/docarray/array/storage/redis/getsetdel.py
+++ b/docarray/array/storage/redis/getsetdel.py
@@ -90,10 +90,10 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _document_to_redis(self, doc: 'Document') -> Dict:
         extra_columns = {}
 
-        for col, _ in self._config.columns:
-            tag = doc.tags.get(col)
+        for col_desc in self._config.columns:
+            tag = doc.tags.get(col_desc[0])
             if tag is not None:
-                extra_columns[col] = int(tag) if isinstance(tag, bool) else tag
+                extra_columns[col_desc[0]] = int(tag) if isinstance(tag, bool) else tag
 
         payload = {
             'id': doc.id,

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -215,7 +215,8 @@ class BackendMixin(BaseBackendMixin):
                 },
             ]
         }
-        for col, coltype in self._config.columns:
+        for col_desc in self._config.columns:
+            col, col_type = tuple(col_desc)
             new_property = {
                 'dataType': [self._map_type(coltype)],
                 'name': col,
@@ -352,10 +353,10 @@ class BackendMixin(BaseBackendMixin):
         :param value: document to create a payload for
         :return: the payload dictionary
         """
-        columns_dict = {key: val for [key, val] in self._config.columns}
+        columns_dict = {col_desc[0]: col_desc[1] for col_desc in self._config.columns}
         extra_columns = {
-            col: self._map_column(value.tags.get(col), columns_dict[col])
-            for col, _ in self._config.columns
+            col_desc[0]: self._map_column(value.tags.get(col_desc[0]), columns_dict[col_desc[0])
+            for col_desc in self._config.columns
         }
 
         return dict(


### PR DESCRIPTION
Goals:

Try without breaking to enable the usage of `columns` in backend configurations when they are started from YAML as Lists.