### PR TITLE
feat: login required push pull

### DIFF
--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -30,6 +30,7 @@ class PushPullMixin:
     _max_bytes = 4 * 1024 * 1024 * 1024
 
     @staticmethod
+    @hubble.login_required
     def cloud_list(show_table: bool = False) -> List[str]:
         """List all available arrays in the cloud.
 
@@ -73,6 +74,7 @@ class PushPullMixin:
         return result
 
     @staticmethod
+    @hubble.login_required
     def cloud_delete(name: str) -> None:
         """
         Delete a DocumentArray from the cloud.
@@ -148,6 +150,7 @@ class PushPullMixin:
 
         return items
 
+    @hubble.login_required
     def push(
         self,
         name: str,
@@ -250,6 +253,7 @@ class PushPullMixin:
             response.raise_for_status()
 
     @classmethod
+    @hubble.login_required
     def pull(
         cls: Type['T'],
         name: str,

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -4,6 +4,7 @@ from io import BytesIO
 
 import pytest
 import requests
+from hubble import Client
 
 from docarray import DocumentArray, Document, dataclass
 from docarray.helper import random_identity
@@ -62,6 +63,13 @@ def _mock_post(mock, monkeypatch, status_code=requests.codes.ok):
         return PushMockResponse(status_code=status_code)
 
     monkeypatch.setattr(requests, 'post', _mocker)
+
+
+def _mock_get_user_info(mock, monkeypatch):
+    def _get_user_info(obj):
+        return {}
+
+    monkeypatch.setattr(Client, 'get_user_info', _get_user_info)
 
 
 def _mock_get(mock, monkeypatch, status_code=requests.codes.ok):
@@ -135,26 +143,33 @@ def test_push_fail(mocker, monkeypatch):
     assert mock.call_count == 1
 
 
-def test_api_url_change(mocker, monkeypatch):
-    test_api_url = 'http://localhost:8080'
-    os.environ['JINA_HUBBLE_REGISTRY'] = test_api_url
+@pytest.fixture()
+def set_hubble_registry():
+    os.environ['JINA_HUBBLE_REGISTRY'] = 'http://localhost:8080'
+    yield
+    os.unsetenv('JINA_HUBBLE_REGISTRY')
+
+
+def test_api_url_change(mocker, monkeypatch, set_hubble_registry):
 
     mock = mocker.Mock()
     _mock_post(mock, monkeypatch)
     _mock_get(mock, monkeypatch)
+    _mock_get_user_info(mock, monkeypatch)
 
     docs = random_docs(2)
     name = random_identity()
     docs.push(name)
     docs.pull(name)
 
-    del os.environ['JINA_HUBBLE_REGISTRY']
-
-    assert mock.call_count == 3  # 1 for push, 1 for pull, 1 for download
+    assert (
+        mock.call_count >= 3
+    )  # at least 1 for push, 1 for pull, 1 for download + extra for auth
 
     _, push_kwargs = mock.call_args_list[0]
     _, pull_kwargs = mock.call_args_list[1]
 
+    test_api_url = 'http://localhost:8080'
     assert push_kwargs['url'].startswith(test_api_url)
     assert pull_kwargs['url'].startswith(test_api_url)
 

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -147,7 +147,7 @@ def test_push_fail(mocker, monkeypatch):
 def set_hubble_registry():
     os.environ['JINA_HUBBLE_REGISTRY'] = 'http://localhost:8080'
     yield
-    os.unsetenv('JINA_HUBBLE_REGISTRY')
+    del os.environ['JINA_HUBBLE_REGISTRY']
 
 
 def test_api_url_change(mocker, monkeypatch, set_hubble_registry):


### PR DESCRIPTION
Enforce login on `DocumentArray.push/pull` using `hubble.login_required`
