### PR TITLE
fix: adapt to annlite changes

### DIFF
--- a/docarray/array/storage/annlite/find.py
+++ b/docarray/array/storage/annlite/find.py
@@ -37,7 +37,7 @@ class FindMixin:
         if n_rows == 1:
             query = query.reshape(1, -1)
 
-        _, match_docs = self._annlite._search_documents(
+        _, match_docs = self._annlite.search_by_vectors(
             query, limit=limit, filter=filter or {}, include_metadata=not only_id
         )
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             'qdrant-client~=0.7.3',
         ],
         'annlite': [
-            'annlite>=0.3.10',
+            'annlite>=0.3.12',
         ],
         'weaviate': [
             'weaviate-client~=3.3.0',
@@ -103,7 +103,7 @@ setup(
             'jupyterlab',
             'transformers>=4.16.2',
             'weaviate-client~=3.3.0',
-            'annlite>=0.3.10',
+            'annlite>=0.3.12',
             'elasticsearch>=8.2.0',
             'redis>=4.3.0',
             'jina',


### PR DESCRIPTION
annlite in 0.3.12, renames private method `_search_documents` which was used by docarray and makes it a public method.
Therefore, we correct the method name in docarray