### PR TITLE
feat: allow pass parameters to load_uri_to*

### DIFF
--- a/docarray/document/mixins/blob.py
+++ b/docarray/document/mixins/blob.py
@@ -9,13 +9,14 @@ if TYPE_CHECKING:
 class BlobDataMixin:
     """Provide helper functions for :class:`Document` to handle binary data."""
 
-    def load_uri_to_blob(self: 'T') -> 'T':
+    def load_uri_to_blob(self: 'T', **kwargs) -> 'T':
         """Convert :attr:`.uri` to :attr:`.blob` inplace.
         Internally it downloads from the URI and set :attr:`blob`.
 
+        :param kwargs: keyword arguments to pass to `:meth:_uri_to_blob` such as timeout
         :return: itself after processed
         """
-        self.blob = _uri_to_blob(self.uri)
+        self.blob = _uri_to_blob(self.uri, **kwargs)
         return self
 
     def convert_blob_to_datauri(

--- a/docarray/document/mixins/helper.py
+++ b/docarray/document/mixins/helper.py
@@ -4,16 +4,16 @@ import urllib.request
 from contextlib import nullcontext
 
 
-def _uri_to_blob(uri: str) -> bytes:
+def _uri_to_blob(uri: str, **kwargs) -> bytes:
     """Convert uri to blob
     Internally it reads uri into blob.
-
     :param uri: the uri of Document
+    :param kwargs: keyword arguments to pass to `urlopen` such as timeout
     :return: blob bytes.
     """
     if urllib.parse.urlparse(uri).scheme in {'http', 'https', 'data'}:
         req = urllib.request.Request(uri, headers={'User-Agent': 'Mozilla/5.0'})
-        with urllib.request.urlopen(req) as fp:
+        with urllib.request.urlopen(req, **kwargs) as fp:
             return fp.read()
     elif os.path.exists(uri):
         with open(uri, 'rb') as fp:

--- a/docarray/document/mixins/helper.py
+++ b/docarray/document/mixins/helper.py
@@ -11,9 +11,11 @@ def _uri_to_blob(uri: str, **kwargs) -> bytes:
     :param kwargs: keyword arguments to pass to `urlopen` such as timeout
     :return: blob bytes.
     """
+    timeout = kwargs.get('timeout', None)
     if urllib.parse.urlparse(uri).scheme in {'http', 'https', 'data'}:
         req = urllib.request.Request(uri, headers={'User-Agent': 'Mozilla/5.0'})
-        with urllib.request.urlopen(req, **kwargs) as fp:
+        urlopen_kwargs = {'timeout': timeout} if timeout is not None else {}
+        with urllib.request.urlopen(req, **urlopen_kwargs) as fp:
             return fp.read()
     elif os.path.exists(uri):
         with open(uri, 'rb') as fp:

--- a/docarray/document/mixins/image.py
+++ b/docarray/document/mixins/image.py
@@ -175,17 +175,19 @@ class ImageDataMixin:
         width: Optional[int] = None,
         height: Optional[int] = None,
         channel_axis: int = -1,
+        **kwargs,
     ) -> 'T':
         """Convert the image-like :attr:`.uri` into :attr:`.tensor`
 
         :param width: the width of the image tensor.
         :param height: the height of the tensor.
         :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
+        :param kwargs: keyword arguments to pass to `:meth:_uri_to_blob` such as timeout
 
         :return: itself after processed
         """
 
-        buffer = _uri_to_blob(self.uri)
+        buffer = _uri_to_blob(self.uri, **kwargs)
         tensor = _to_image_tensor(io.BytesIO(buffer), width=width, height=height)
         self.tensor = _move_channel_axis(tensor, original_channel_axis=channel_axis)
         return self

--- a/docarray/document/mixins/text.py
+++ b/docarray/document/mixins/text.py
@@ -12,13 +12,14 @@ if TYPE_CHECKING:
 class TextDataMixin:
     """Provide helper functions for :class:`Document` to support text data."""
 
-    def load_uri_to_text(self: 'T', charset: str = 'utf-8') -> 'T':
+    def load_uri_to_text(self: 'T', charset: str = 'utf-8', **kwargs) -> 'T':
         """Convert :attr:`.uri` to :attr`.text` inplace.
 
         :param charset: charset may be any character set registered with IANA
+        :param kwargs: keyword arguments to pass to `:meth:_uri_to_blob` such as timeout
         :return: itself after processed
         """
-        blob = _uri_to_blob(self.uri)
+        blob = _uri_to_blob(self.uri, **kwargs)
         self.text = blob.decode(charset)
         return self
 


### PR DESCRIPTION
Goals:

Capture properly Exceptions from `load_to_uri*` methods and allow to pass extra keyword arguments as `timeout`