### PR TITLE
fix: remove check of default value in _non_empty_fields

### DIFF
--- a/docarray/score/data.py
+++ b/docarray/score/data.py
@@ -23,12 +23,7 @@ class NamedScoreData:
             if not f_name.startswith('_'):
                 v = getattr(self, f_name)
                 if v is not None:
-                    if f_name not in default_values:
-                        r.append(f_name)
-                    else:
-                        dv = default_values[f_name]
-                        if v != dv:
-                            r.append(f_name)
+                    r.append(f_name)
 
         return tuple(r)
 

--- a/tests/unit/test_named_score.py
+++ b/tests/unit/test_named_score.py
@@ -1,0 +1,7 @@
+from docarray.score import NamedScore
+
+
+def test_str_representation():
+    assert str(NamedScore(value=0.0)) == str({'value': 0.0})
+    assert str(NamedScore(value=None)) == str(dict())
+    assert str(NamedScore(value=0.3)) == str({'value': 0.3})


### PR DESCRIPTION
Goals:

- Scores with value 0.0 should also be presented in the string representation of NamedScores
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
