### PR TITLE
fix(array): in memory extend should check types before extend

### DIFF
--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -58,6 +58,12 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
     def _extend(self, values: Iterable["Document"], **kwargs) -> None:
         values = list(values)  # consume the iterator only once
+
+        if not all(isinstance(x, Document) for x in values):
+            for x in values:
+                if not isinstance(x, Document):
+                    raise AttributeError(f"{x} is not a Document")
+
         last_idx = len(self._id2offset)
         self._data.extend(values)
         self._id_to_index.update({d.id: i + last_idx for i, d in enumerate(values)})

--- a/docarray/array/storage/memory/seqlike.py
+++ b/docarray/array/storage/memory/seqlike.py
@@ -10,7 +10,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     """Implement sequence-like methods"""
 
     @needs_id2offset_rebuild
-    def insert(self, index: int, value: 'Document'):
+    def insert(self, index: int, value: "Document"):
         """Insert `doc` at `index`.
 
         :param index: Position of the insertion.
@@ -18,7 +18,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
         """
         self._data.insert(index, value)
 
-    def _append(self, value: 'Document', **kwargs):
+    def _append(self, value: "Document", **kwargs):
         """Append `doc` to the end of the array.
 
         :param value: The doc needs to be appended.
@@ -37,10 +37,10 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     def __len__(self):
         return len(self._data)
 
-    def __iter__(self) -> Iterator['Document']:
+    def __iter__(self) -> Iterator["Document"]:
         yield from self._data
 
-    def __contains__(self, x: Union[str, 'Document']):
+    def __contains__(self, x: Union[str, "Document"]):
         if isinstance(x, str):
             return x in self._id2offset
         elif isinstance(x, Document):
@@ -49,14 +49,14 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             return False
 
     def __repr__(self):
-        return f'<DocumentArray (length={len(self)}) at {id(self)}>'
+        return f"<DocumentArray (length={len(self)}) at {id(self)}>"
 
     def __add__(self, other: Union['Document', Iterable['Document']]):
         v = type(self)(self)
         v.extend(other)
         return v
 
-    def _extend(self, values: Iterable['Document'], **kwargs) -> None:
+    def _extend(self, values: Iterable["Document"], **kwargs) -> None:
         values = list(values)  # consume the iterator only once
         last_idx = len(self._id2offset)
         self._data.extend(values)

--- a/tests/unit/array/mixins/test_extend.py
+++ b/tests/unit/array/mixins/test_extend.py
@@ -1,0 +1,13 @@
+import pytest
+from docarray import DocumentArray
+
+
+def test_extend():
+    da = DocumentArray.empty(3)
+    assert len(da) == 3
+
+    with pytest.raises(AttributeError):
+        da.extend([1, 2, 3])
+
+    assert len(da) == 3
+    da.summary()


### PR DESCRIPTION
Goals:

- Fixes https://github.com/jina-ai/docarray/issues/544
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
