### PR TITLE
test: remove call to gc collect

### DIFF
--- a/tests/unit/array/mixins/test_getset.py
+++ b/tests/unit/array/mixins/test_getset.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 import scipy.sparse
@@ -514,9 +512,6 @@ def test_getset_subindex(storage, config):
     ],
 )
 def test_init_subindex(storage, config):
-    if storage == 'redis':
-        gc.collect()
-
     num_top_level_docs = 5
     num_chunks_per_doc = 3
     subindex_configs = (

--- a/tests/unit/array/test_sequence.py
+++ b/tests/unit/array/test_sequence.py
@@ -1,4 +1,3 @@
-import gc
 import tempfile
 import uuid
 
@@ -90,9 +89,6 @@ def update_config_inplace(config, tmpdir, tmpfile):
 def test_context_manager_from_disk(storage, config, start_storage, tmpdir, tmpfile):
     config = config
     update_config_inplace(config, tmpdir, tmpfile)
-
-    if storage == 'redis':
-        gc.collect()
 
     da = DocumentArray(storage=storage, config=config)
 


### PR DESCRIPTION
Goals:

In tests we are calling `gc.collect` which does not make sense imo