### PR TITLE
chore: add securitiy policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+Security is very important for DocArray and its community. 
+
+## Supported Versions
+
+The latest versions of DocArray are supported.
+
+
+## Reporting a Vulnerability
+
+If you think you found a vulnerability, and even if you are not sure about it, please report it right away by sending an email to: security@jina.ai. Please try to be as explicit as possible, describing all the steps and example code to reproduce the security issue.
+
+Our team will review it thoroughly and get back to you.
+
+Please restrain from publicly discussing a potential security vulnerability on Github issues or in Slack community. 🙊 It's better to discuss privately and try to find a solution first, to limit the potential impact as much as possible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ The latest versions of DocArray are supported.
 
 ## Reporting a Vulnerability
 
-If you think you found a vulnerability, and even if you are not sure about it, please report it right away by sending an email to: security@jina.ai. Please try to be as explicit as possible, describing all the steps and example code to reproduce the security issue.
+If you think you've found a vulnerability, even if you are not sure about it, please report it right away by sending an email to security@jina.ai. Please try to be as explicit as possible, describing all the steps and example code to reproduce the security issue.
 
 Our team will review it thoroughly and get back to you.
 
-Please restrain from publicly discussing a potential security vulnerability on Github issues or in Slack community. 🙊 It's better to discuss privately and try to find a solution first, to limit the potential impact as much as possible.
+Please refrain from publicly discussing a potential security vulnerability on Github issues or in Slack community. It's better to discuss it privately and try to find a solution first, to limit the potential impact as much as possible.


### PR DESCRIPTION
Signed-off-by: samsja <55492238+samsja@users.noreply.github.com>

# Context

OpenSSF badge require a security policy. We have it on jina but not on docarray (https://github.com/jina-ai/jina/blob/master/SECURITY.md)

# What this PR do:

Add a (smally) modified security policy from the jina one
