### PR TITLE
feat: add config for pca in annlite

### DIFF
--- a/docarray/array/storage/annlite/backend.py
+++ b/docarray/array/storage/annlite/backend.py
@@ -27,6 +27,7 @@ class AnnliteConfig:
     ef_construction: Optional[int] = None
     ef_search: Optional[int] = None
     max_connection: Optional[int] = None
+    n_components: Optional[int] = None
     columns: Optional[Union[List[Tuple[str, str]], Dict[str, str]]] = None
 
 

--- a/docs/advanced/document-store/annlite.md
+++ b/docs/advanced/document-store/annlite.md
@@ -38,14 +38,15 @@ Other functions behave the same as in-memory DocumentArray.
 
 The following configs can be set:
 
-| Name              | Description                                                                           | Default                                                       |
-|-------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| `n_dim`           | Number of dimensions of embeddings to be stored and retrieved                         | **This is always required**                                   |
-| `data_path`       | The data folder where the data is located                                             | **A random temp folder**                                      |
-| `metric`          | Distance metric to be used during search. Can be 'cosine', 'dot' or 'euclidean'       | 'cosine'                                                      |
-| `ef_construction` | The size of the dynamic list for the nearest neighbors (used during the construction) | `None`, defaults to the default value in the AnnLite package* |
-| `ef_search`       | The size of the dynamic list for the nearest neighbors (used during the search)       | `None`, defaults to the default value in the AnnLite package* |
-| `max_connection`  | The number of bi-directional links created for every new element during construction. | `None`, defaults to the default value in the AnnLite package* |
+| Name              | Description                                                                                             | Default                                                       |
+|-------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `n_dim`           | Number of dimensions of embeddings to be stored and retrieved                                           | **This is always required**                                   |
+| `data_path`       | The data folder where the data is located                                                               | **A random temp folder**                                      |
+| `metric`          | Distance metric to be used during search. Can be 'cosine', 'dot' or 'euclidean'                         | 'cosine'                                                      |
+| `ef_construction` | The size of the dynamic list for the nearest neighbors (used during the construction)                   | `None`, defaults to the default value in the AnnLite package* |
+| `ef_search`       | The size of the dynamic list for the nearest neighbors (used during the search)                         | `None`, defaults to the default value in the AnnLite package* |
+| `max_connection`  | The number of bi-directional links created for every new element during construction.                   | `None`, defaults to the default value in the AnnLite package* |
+| `n_components`    | The output dimension of PCA model. Should be a positive number and less than `n_dim` if it's not `None` | `None`, defaults to the default value in the AnnLite package* |
 
 *You can check the default values in [the AnnLite source code](https://github.com/jina-ai/annlite/blob/main/annlite/core/index/hnsw/index.py)
 


### PR DESCRIPTION
Goals: Enable loading indexer with PCA in DocumentArray AnnLite backend.

In AnnLite we load the model by their `params_hash` which compute by hashing `n_dim`, `n_components`... 
So in order to successfully load the dumped indexer, we need to pass the `n_components` to AnnLite.
 
- add a new parameter `n_components`, which is the output dimension of PCA, in `annlite/backend.py` AnnliteConfig
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
