### PR TITLE
feat(audio): allow to load from uri with a custom sample rate

### DIFF
--- a/docarray/document/mixins/audio.py
+++ b/docarray/document/mixins/audio.py
@@ -88,6 +88,6 @@ class AudioDataMixin:
         """
         import librosa
 
-        self.tensor, self.tags['sample_rate'] = librosa.load(self.uri, sr=sample_rate)
+        self.tensor, _ = librosa.load(self.uri, sr=sample_rate)
 
         return self

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'requests',
             'matplotlib',
             'Pillow',
+            'librosa',
             'trimesh',
             'scipy',
             'av',

--- a/tests/unit/document/test_audio.py
+++ b/tests/unit/document/test_audio.py
@@ -1,0 +1,22 @@
+import copy
+import os
+import pytest
+
+from docarray.document.generators import from_files
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_librosa_and_wave_compatibility(pytestconfig):
+    for d in from_files(f'{cur_dir}/toydata/*.wav'):
+        copy_d = copy.deepcopy(d)
+        d._load_uri_to_audio_tensor_wave()
+        copy_d._load_uri_to_audio_tensor_librosa()
+
+        assert (d.tensor == copy_d.tensor).all()
+
+
+@pytest.mark.parametrize('sr', [None, 16_000, 44_000])
+def test_load_audio(pytestconfig, sr):
+    for d in from_files(f'{cur_dir}/toydata/*.wav'):
+        d.load_uri_to_audio_tensor(sample_rate=sr)

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -33,6 +33,18 @@ def test_audio_convert_pipe(pytestconfig, tmpdir):
     assert num_d
 
 
+def test_audio_librosa_convert_pipe(pytestconfig, tmpdir):
+    num_d = 0
+    for d in from_files(f'{cur_dir}/toydata/*.wav'):
+        fname = str(tmpdir / f'tmp{num_d}.wav')
+        d.load_uri_to_audio_tensor_librosa()
+        d.tensor = d.tensor[::-1]
+        d.save_audio_tensor_to_file(fname)
+        assert os.path.exists(fname)
+        num_d += 1
+    assert num_d
+
+
 def test_image_convert_pipe(pytestconfig):
     for d in from_files(f'{pytestconfig.rootdir}/.github/**/*.png'):
         (


### PR DESCRIPTION
# Context

It might be useful to load an audio with a given sample rate. This is for example needed for the [WhisperExecutor](https://github.com/samsja/audio2image/tree/main/executors/whisper)

Atm the only way to use this executor properly is to do 

```python
from docarray import Document
import librosa

d = Document(uri='audio.wav')
d.tensor = librosa.load(d.uri, sr=16_000)[0]
```

# What this pr do

Allow to load with a sample rate, the above example would become

```python
from docarray import Document
d = Document(uri='audio.wav').load_uri_to_audio_tensor(sample_rate = 16_000)
```
This feel more docarray-ic

This PR need to use librosa as dependency therefore can only be merged once we figure it out what do to with different dependency for multi modality see this [issue](https://github.com/jina-ai/docarray/issues/605)

Moreover using librosa as a potiential backend could allow more audio features, like reading for mp3 etcc