### PR TITLE
fix: allow optional str int etcc in dataclass

### DIFF
--- a/docarray/dataclasses/setter.py
+++ b/docarray/dataclasses/setter.py
@@ -44,6 +44,8 @@ def audio_setter(value) -> 'Document':
 
     if isinstance(value, np.ndarray):
         return Document(tensor=value, _metadata={'audio_type': 'ndarray'})
+    elif value is None:
+        return Document(_metadata={'audio_type': None})
     else:
         return Document(
             uri=value, modality='audio', _metadata={'audio_type': 'uri'}
@@ -55,6 +57,8 @@ def video_setter(value) -> 'Document':
 
     if isinstance(value, np.ndarray):
         return Document(tensor=value, _metadata={'video_type': 'ndarray'})
+    elif value is None:
+        return Document(_metadata={'video_type': None})
     else:
         return Document(
             uri=value, modality='video', _metadata={'video_type': 'uri'}
@@ -66,6 +70,8 @@ def mesh_setter(value) -> 'Document':
 
     if isinstance(value, np.ndarray):
         return Document(tensor=value, _metadata={'mesh_type': 'ndarray'})
+    elif value is None:
+        return Document(_metadata={'mesh_type': None})
     else:
         return Document(
             uri=value, modality='mesh', _metadata={'mesh_type': 'uri'}
@@ -77,6 +83,8 @@ def blob_setter(value) -> 'Document':
 
     if isinstance(value, bytes):
         return Document(blob=value, _metadata={'blob_type': 'bytes'})
+    elif value is None:
+        return Document(_metadata={'blob_type': None})
     else:
         return Document(uri=value, _metadata={'blob_type': 'uri'}).load_uri_to_blob()
 
@@ -90,4 +98,9 @@ def json_setter(value) -> 'Document':
 def tabular_setter(value) -> 'Document':
     from docarray import Document, DocumentArray
 
-    return Document(uri=value, chunks=DocumentArray.from_csv(value), modality='tabular')
+    if value is None:
+        return Document(modality='tabular')
+    else:
+        return Document(
+            uri=value, chunks=DocumentArray.from_csv(value), modality='tabular'
+        )

--- a/docarray/dataclasses/types.py
+++ b/docarray/dataclasses/types.py
@@ -297,3 +297,34 @@ def _get_doc_nested_attribute(attribute_doc: 'Document', nested_cls: Type['T']) 
     if not is_multimodal(nested_cls):
         raise ValueError(f'Nested attribute `{nested_cls.__name__}` is not a dataclass')
     return nested_cls(**_from_document(nested_cls, attribute_doc))
+
+
+def _is_optional(type_) -> bool:
+    """
+    check if a type is Optional. Optional is a alias for Union[X, None]
+    :param type_: the type to check if it is an Optional or not
+    :return: a boolean saying if the type in Optional
+    """
+    origin = getattr(type_, '__origin__', None)
+
+    if origin != typing.Union:  # Optional is a Union
+        return False
+
+    args = getattr(type_, '__args__', None)
+
+    if args is None:
+        return False
+
+    if not (type(None) in args):  # Optional as the NoneType in its args
+        return False
+
+    if (
+        len(args) > 2
+    ):  # If the Union has more that two options then it is not an Optional
+        return False
+
+    return True
+
+
+def _get_optional_subtype(optional_type):
+    return optional_type.__args__[0]

--- a/docarray/dataclasses/types.py
+++ b/docarray/dataclasses/types.py
@@ -107,7 +107,11 @@ def field(**kwargs) -> Field:
 
 
 def _is_field(f) -> bool:
-    return isinstance(f, Field) and getattr(f, 'setter') and getattr(f, 'getter')
+    return (
+        isinstance(f, Field)
+        and bool(getattr(f, 'setter', None))
+        and bool(getattr(f, 'getter', None))
+    )
 
 
 _TYPES_REGISTRY = {

--- a/docarray/dataclasses/types.py
+++ b/docarray/dataclasses/types.py
@@ -127,6 +127,11 @@ _TYPES_REGISTRY = {
     Blob: lambda x: field(setter=blob_setter, getter=blob_getter, _source_field=x),
     Mesh: lambda x: field(setter=mesh_setter, getter=mesh_getter, _source_field=x),
 }
+_TYPES_REGISTRY_OPTIONAL = dict()
+for type_ in _TYPES_REGISTRY.keys():
+    _TYPES_REGISTRY_OPTIONAL[Optional[type_]] = _TYPES_REGISTRY[type_]
+
+_TYPES_REGISTRY.update(_TYPES_REGISTRY_OPTIONAL)
 
 
 @overload

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -7,7 +7,6 @@ from docarray.dataclasses.types import (
     is_multimodal,
     _is_field,
     _is_optional,
-    _is_optional_field,
     _get_optional_subtype,
 )
 from docarray.dataclasses.types import AttributeType

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -76,7 +76,9 @@ class MultiModalMixin:
                 doc, attribute_type = cls._from_obj(attribute, field.type, field)
                 multi_modal_schema[key] = {
                     'attribute_type': attribute_type,
-                    'type': field.type.__name__,
+                    'type': field.type.__name__
+                    if not (_is_optional(field.type))
+                    else f'Optional[{_get_optional_subtype(field.type).__name__}]',
                     'position': len(root.chunks),
                 }
                 root.chunks.append(doc)

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -58,11 +58,16 @@ class MultiModalMixin:
                     'type': f'Optional[{_get_optional_subtype(field.type).__name__}]',
                 }
 
-            elif field.type == bytes and not _is_field(field):
-                tags[key] = base64.b64encode(attribute).decode()
+            elif field.type in [bytes, Optional[bytes]] and not _is_field(field):
+                tags[key] = (
+                    base64.b64encode(attribute).decode() if attribute else attribute
+                )
                 multi_modal_schema[key] = {
                     'attribute_type': AttributeType.PRIMITIVE,
-                    'type': field.type.__name__,
+                    'type': field.type.__name__
+                    if not (_is_optional(field.type))
+                    else f'Optional[{_get_optional_subtype(field.type).__name__}]',
+                    'position': len(root.chunks),
                 }
 
             elif field.type == Optional[bytes] and not _is_field(field):

--- a/tests/unit/array/test_dataclass.py
+++ b/tests/unit/array/test_dataclass.py
@@ -3,21 +3,37 @@ from typing import Optional, Union
 import pytest
 
 from docarray import Document
-from docarray.typing import Text, Image, Audio, JSON
+from docarray.typing import Image, Text, Audio, Video, Mesh, Tabular, Blob, JSON, URI
 from docarray.dataclasses.types import _is_optional, dataclass
 
 
-def test_dataclass_optional_value():
+@pytest.mark.parametrize(
+    'type_', [Image, Text, Audio, Video, Mesh, Tabular, Blob, JSON, URI]
+)
+def test_dataclass_optional_value(type_):
+    @dataclass
+    class MultiModalDoc:
+        foo: Optional[type_] = None
+
+    d = Document(MultiModalDoc())
+
+    assert len(d.chunks) == 1
+    assert isinstance(d.foo, Document)
+
+
+def test_dataclass_optional_value_text():
     @dataclass
     class MultiModalDoc:
         foo: Optional[Text] = None
 
     d = Document(MultiModalDoc())
-    assert d.foo.text is None
-    d.bar.foo = 'world'  # wont work
+    assert (
+        d.foo.text is Document(text=None).text
+    )  # the None is automatically transform to '' in Document init
+    d.foo.text = 'world'
 
     assert len(d.chunks) == 1
-    assert isinstance(d.bar, Document)
+    assert isinstance(d.foo, Document)
 
 
 def test_dataclass_optional_value_str():

--- a/tests/unit/array/test_dataclass.py
+++ b/tests/unit/array/test_dataclass.py
@@ -4,15 +4,7 @@ import pytest
 
 from docarray import Document
 from docarray.typing import Text, Image, Audio, JSON
-from docarray.dataclasses.types import _is_optional, dataclass, _is_optional_field
-
-
-def test_dataclass_opregetional_value():
-    @dataclass
-    class MultiModalDoc:
-        foo: Text
-
-    d = Document(MultiModalDoc(foo='sfdssf'))
+from docarray.dataclasses.types import _is_optional, dataclass
 
 
 def test_dataclass_optional_value():
@@ -21,8 +13,8 @@ def test_dataclass_optional_value():
         foo: Optional[Text] = None
 
     d = Document(MultiModalDoc())
-    assert d.bar.text is None
-    d.bar.text = 'world'  # wont work
+    assert d.foo.text is None
+    d.bar.foo = 'world'  # wont work
 
     assert len(d.chunks) == 1
     assert isinstance(d.bar, Document)

--- a/tests/unit/array/test_dataclass.py
+++ b/tests/unit/array/test_dataclass.py
@@ -1,0 +1,60 @@
+from typing import Optional, Union
+
+import pytest
+
+from docarray import Document
+from docarray.typing import Text, Image, Audio, JSON
+from docarray.dataclasses.types import _is_optional, dataclass, _is_optional_field
+
+
+def test_dataclass_opregetional_value():
+    @dataclass
+    class MultiModalDoc:
+        foo: Text
+
+    d = Document(MultiModalDoc(foo='sfdssf'))
+
+
+def test_dataclass_optional_value():
+    @dataclass
+    class MultiModalDoc:
+        foo: Optional[Text] = None
+
+    d = Document(MultiModalDoc())
+    assert d.bar.text is None
+    d.bar.text = 'world'  # wont work
+
+    assert len(d.chunks) == 1
+    assert isinstance(d.bar, Document)
+
+
+def test_dataclass_optional_value_str():
+    @dataclass
+    class MultiModalDoc:
+        foo: Optional[str] = None
+
+    d = Document(MultiModalDoc())
+    assert d.tags['foo'] is None
+    d.tags['foo'] = 'world'
+
+    assert len(d.chunks) == 0
+
+
+def test_dataclass_optional_value_bytes():
+    @dataclass
+    class MultiModalDoc:
+        foo: Optional[bytes] = None
+
+    d = Document(MultiModalDoc())
+    assert d.tags['foo'] is None
+    assert len(d.chunks) == 0
+
+
+@pytest.mark.parametrize('type_', [str, int, Text, Image, Audio, JSON])
+def test_is_optional(type_):
+    assert _is_optional(Optional[type])
+
+
+@pytest.mark.parametrize('type_', [None, str, int, Text, Union[None, int, int]])
+def test_is_not_optional(type_):
+    assert not (_is_optional(type))


### PR DESCRIPTION
# Context 

Original issue : https://github.com/jina-ai/docarray/issues/591

Optional field and docarray dataclass does not play well

Indeed for instance one would except that if I create a Document out of a dataclass with an `Optional[Text]` field with default value `None` that the Document will contain an empty Document in bar (added to the chunk). Atm These chunk Document is not created as shown in this code


```python
from typing import Optional

from docarray import dataclass, Document
from docarray.typing import Text


@dataclass
class WebDoc:
    foo: Text
    bar: Optional[Text] = None


d = Document(WebDoc(foo='hello'))
d.bar.text = 'world' # wont work

assert len(d.chunks) == 2  # fail
assert isinstance(d.bar, Document)  # fail
>>>Traceback (most recent call last):
  File "/home/sami/trash/test.py", line 16, in <module>
    d = Document(WebDoc(foo='hello'))
  File "/home/sami/Documents/workspace/Jina/docarray/docarray/document/__init__.py", line 147, in __init__
    super().__init__(*args, **kwargs)
  File "/home/sami/Documents/workspace/Jina/docarray/docarray/base.py", line 38, in __init__
    self._data = type(self)._from_dataclass(_obj)._data
  File "/home/sami/Documents/workspace/Jina/docarray/docarray/document/mixins/multimodal.py", line 116, in _from_dataclass
    raise TypeError(
TypeError: Unsupported type annotation on field `None`
```


# What this pr do

it allows to do
```python


  @dataclass
  class MultiModalDoc:
      foo: Optional[Text] = None

  d = Document(MultiModalDoc())

  d.foo.text = 'world'  
```
This mean it will create a chunk empty Document. Before it was doing nothing

This work as well with non docarray type.
```python
@dataclass
class MultiModalDoc:
    foo: Optional[str] = None

d = Document(MultiModalDoc())
d.tags['foo'] = 'blabla'
```

