### PR TITLE
chore: disable annlite test

### DIFF
--- a/tests/unit/array/mixins/test_plot.py
+++ b/tests/unit/array/mixins/test_plot.py
@@ -24,7 +24,8 @@ from docarray.array.redis import DocumentArrayRedis, RedisConfig
     [
         (DocumentArray, None),
         (DocumentArraySqlite, None),
-        (DocumentArrayAnnlite, AnnliteConfig(n_dim=128)),
+        # TODO: restore this after annlite issue is fixed in #622
+        # (DocumentArrayAnnlite, AnnliteConfig(n_dim=128)),
         # (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
         (DocumentArrayQdrant, QdrantConfig(n_dim=128, scroll_batch_size=8)),
         (DocumentArrayElastic, ElasticConfig(n_dim=128)),


### PR DESCRIPTION
Disable failing Annlite test: tests/unit/array/mixins/test_plot.py::test_sprite_fail_tensor_success_uri
To be reverted when https://github.com/jina-ai/docarray/pull/622 is merged