### PR TITLE
feat: add filter support for qdrant document store

### DIFF
--- a/docarray/array/storage/qdrant/find.py
+++ b/docarray/array/storage/qdrant/find.py
@@ -4,10 +4,10 @@ from typing import (
     TypeVar,
     Sequence,
     List,
-    Dict,
+    Union,
     Optional,
+    Dict,
 )
-
 from qdrant_client.http.models.models import Distance
 
 from docarray import Document, DocumentArray
@@ -103,3 +103,32 @@ class FindMixin:
                 da = self._find_similar_vectors(q, limit=limit, filter=filter)
                 closest_docs.append(da)
             return closest_docs
+
+    def _find_with_filter(
+        self, filter: Optional[Dict], limit: Optional[Union[int, float]] = 10
+    ):
+        list_of_points, _offset = self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filter,
+            with_payload=True,
+            limit=limit,
+        )
+        da = DocumentArray()
+        for result in list_of_points[:limit]:
+            doc = Document.from_base64(
+                result.payload['_serialized'], **self.serialize_config
+            )
+            da.append(doc)
+        return da
+
+    def _filter(
+        self, filter: Optional[Dict], limit: Optional[Union[int, float]] = 10
+    ) -> 'DocumentArray':
+        """Returns a subset of documents by filtering by the given filter (`Qdrant` filter)..
+        :param limit: number of retrieved items
+        :param filter: filter query used for filtering.
+        For more information: https://docarray.jina.ai/advanced/document-store/qdrant/#qdrant
+        :return: a `DocumentArray` containing the `Document` objects that verify the filter.
+        """
+
+        return self._find_with_filter(filter, limit=limit)

--- a/docs/advanced/document-store/index.md
+++ b/docs/advanced/document-store/index.md
@@ -159,15 +159,15 @@ Creating DocumentArrays without indexes is useful during prototyping but should 
 DocArray supports multiple storage backends with different search features. The following table showcases relevant functionalities that are supported (✅) or not supported (❌) in DocArray depending on the backend:
 
 
-| Name                                  | Construction                             |  vector search | vector search + filter | filter        |
-|---------------------------------------|------------------------------------------|----------------|------------------------|---------------|
-| In memory                             | `DocumentArray()`                        | ✅             | ✅                     | ✅            |
-| [`Sqlite`](./sqlite.md)               | `DocumentArray(storage='sqlite')`        | ❌             | ❌                     | ✅            | 
-| [`Weaviate`](./weaviate.md)           | `DocumentArray(storage='weaviate')`      | ✅             | ✅                     | ✅            |
-| [`Qdrant`](./qdrant.md)               | `DocumentArray(storage='qdrant')`        | ✅             | ✅                     | ❌            |
-| [`AnnLite`](./annlite.md)             | `DocumentArray(storage='annlite')`       | ✅             | ✅                     | ✅            |
-| [`ElasticSearch`](./elasticsearch.md) | `DocumentArray(storage='elasticsearch')` | ✅             | ✅                     | ✅            |
-| [`Redis`](./redis.md)                 | `DocumentArray(storage='redis')`         | ✅             | ✅                     | ✅            |
+| Name                                  | Construction                             | Vector search | Vector search + Filter | Filter |
+|---------------------------------------|------------------------------------------|---------------|------------------------|--------|
+| In memory                             | `DocumentArray()`                        | ✅             | ✅                      | ✅      |
+| [`SQLite`](./sqlite.md)               | `DocumentArray(storage='sqlite')`        | ❌             | ❌                      | ✅      | 
+| [`Weaviate`](./weaviate.md)           | `DocumentArray(storage='weaviate')`      | ✅             | ✅                      | ✅      |
+| [`Qdrant`](./qdrant.md)               | `DocumentArray(storage='qdrant')`        | ✅             | ✅                      | ✅      |
+| [`AnnLite`](./annlite.md)             | `DocumentArray(storage='annlite')`       | ✅             | ✅                      | ✅      |
+| [`ElasticSearch`](./elasticsearch.md) | `DocumentArray(storage='elasticsearch')` | ✅             | ✅                      | ✅      |
+| [`Redis`](./redis.md)                 | `DocumentArray(storage='redis')`         | ✅             | ✅                      | ✅      |
 
 The right backend choice depends on the scale of your data, the required performance and the desired ease of setup. For most use cases we recommend starting with [`AnnLite`](./annlite.md).
 [**Check our One Million Scale Benchmark for more details**](./benchmark#conclusion).


### PR DESCRIPTION
Goals:

- Currently the Qdrant backend doesn't support filter, this PR is to support filter method in Qdrant from docarray 
- ...
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
