### PR TITLE
feat: add args to load_uri_to_video_tensor

### DIFF
--- a/docarray/document/mixins/video.py
+++ b/docarray/document/mixins/video.py
@@ -97,15 +97,19 @@ class VideoDataMixin:
             if show_window:
                 cv2.destroyWindow(window_title)
 
-    def load_uri_to_video_tensor(self: 'T', only_keyframes: bool = False) -> 'T':
+    def load_uri_to_video_tensor(
+        self: 'T', only_keyframes: bool = False, **kwargs
+    ) -> 'T':
         """Convert a :attr:`.uri` to a video ndarray :attr:`.tensor`.
 
         :param only_keyframes: only keep the keyframes in the video
+        :param kwargs: supports all keyword arguments that are being supported by av.open() as
+            described in: https://pyav.org/docs/stable/api/_globals.html?highlight=open#av.open
         :return: Document itself after processed
         """
         import av
 
-        with av.open(self.uri) as container:
+        with av.open(self.uri, **kwargs) as container:
             if only_keyframes:
                 stream = container.streams.video[0]
                 stream.codec_context.skip_frame = 'NONKEY'


### PR DESCRIPTION
Goals:

- Solving this issue: https://github.com/jina-ai/docarray/issues/656
- [ ] Add keyword arguments that are available in `av.open()` to `load_uri_to_video_tensor()` (as listed in https://pyav.org/docs/stable/api/_globals.html?highlight=open#av.open):
  - e.g., timeout: How many seconds to wait for data before giving up, as a float, or a (open timeout, read timeout) tuple.
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
