### PR TITLE
chore: move to the new hub url

### DIFF
--- a/docs/_templates/sidebar/navigation.html
+++ b/docs/_templates/sidebar/navigation.html
@@ -7,7 +7,7 @@
                 <img class="sidebar-ecosys-logo only-light-line" src="{{ pathto('_static/search-light.svg', 1) }}">
                 <img class="sidebar-ecosys-logo only-dark-line" src="{{ pathto('_static/search-dark.svg', 1) }}">
                 Jina</a></li>
-        <li class="toctree-l1"><a class="reference external" href="https://hub.jina.ai">
+        <li class="toctree-l1"><a class="reference external" href="https://cloud.jina.ai">
             <img class="sidebar-ecosys-logo only-light-line" src="{{ pathto('_static/hub-light.svg', 1) }}">
             <img class="sidebar-ecosys-logo only-dark-line" src="{{ pathto('_static/hub-dark.svg', 1) }}">
             Jina Hub</a></li>

--- a/docs/fundamentals/dataclass/index.md
+++ b/docs/fundamentals/dataclass/index.md
@@ -153,7 +153,7 @@ Having those in mind, to represent a multimodal document it seems that we need t
 Having this representation has many benefits, to name a few:
 - One can process and apply deep learning methods on each Document (aka modality) separately.
 - Or _jointly_, by leveraging the nested relationship at the parent level.
-- One can enjoy all DocArray API, [Jina API](https://github.com/jina-ai/jina), [Hub Executors](https://hub.jina.ai), [CLIP-as-service](https://clip-as-service.jina.ai/) and [Finetuner](https://github.com/jina-ai/finetuner) out of the box, without redesigning the data structure.
+- One can enjoy all DocArray API, [Jina API](https://github.com/jina-ai/jina), [Hub Executors](https://cloud.jina.ai), [CLIP-as-service](https://clip-as-service.jina.ai/) and [Finetuner](https://github.com/jina-ai/finetuner) out of the box, without redesigning the data structure.
 
 ## Understanding the challenges
 

--- a/docs/fundamentals/documentarray/post-external.md
+++ b/docs/fundamentals/documentarray/post-external.md
@@ -18,7 +18,7 @@ r = da.post('grpc://192.168.2.3:12345')
 r.summary()
 ```
 
-One can also use any [Executor from Jina Hub](https://hub.jina.ai), e.g.
+One can also use any [Executor from Jina Hub](https://cloud.jina.ai), e.g.
 ```python
 from docarray import DocumentArray, Document
 
@@ -67,7 +67,7 @@ scheme://netloc[:port][/path]
 | `scheme`  | 1. One of `grpc`, `websocket`, `http`                   | `protocol` of the connected Flow                                                                                                     |
 |           | 2. One of `jinahub`, `jinahub+docker`, `jinhub+sandbox` | Jina hub executor in source code, Docker container, sandbox                                                                          |
 | `netloc`  | 1. Host address                                         | `host` of the connected Flow                                                                                                         |
-|   | 2. Hub Executor name                                    | Any Executor [listed here](https://hub.jina.ai)                                                                                      |
+|   | 2. Hub Executor name                                    | Any Executor [listed here](https://cloud.jina.ai)                                                                                      |
 |   | 3. Executor version(optional)                           | Such as v0.1.1, v0.1.1-gpu, by default latest                                                                                        |
 | `:port` | e.g. `:55566`                                           | `port` of the connected Flow. This is required when using `scheme` type (1) ; it is ignored when using hub-related `scheme` type (2) |
 | `/path` | e.g. `/foo`                                             | The endpoint of the Executor you want to call.                                                                                       |

--- a/docs/fundamentals/jina-support/index.md
+++ b/docs/fundamentals/jina-support/index.md
@@ -167,7 +167,7 @@ This will start three parallels can improve the overall throughput. [More detail
 
 ### Share and reuse it
 
-One can share and reuse it via [Hub](https://hub.jina.ai). Save your Executor in a folder say `foo` and then:
+One can share and reuse it via [Hub](https://cloud.jina.ai). Save your Executor in a folder say `foo` and then:
 
 ```bash
 jina hub push foo


### PR DESCRIPTION
# Context

`hub.jina.ai` is moving to `cloud.jina.ai`

This pr change the url eveywhere
