### PR TITLE
ci: fix first time build issue on build old docs

### DIFF
--- a/.github/workflows/build-old-docs.yml
+++ b/.github/workflows/build-old-docs.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           cd docs
           for i in $(ls /tmp/artifacts); do unzip "/tmp/artifacts/$i/build.zip"; done
-          rm _versions.json
+          rm _versions.json || true
           wget https://raw.githubusercontent.com/${{ inputs.repo_owner }}/${{ inputs.package }}/main/docs/_versions.json
       - name: Push it up!
         run: |


### PR DESCRIPTION
Goals:

- Patch issue in failing workflow https://github.com/jina-ai/docarray/actions/runs/3320394868
- The issue is due to it being the first time versioned documentation is being added
- The _versions.json file does not exist yet, so the remove command intended to remove the old _versions.json fails
- A condition was added to the line so that failure to remove the old _versions.json are ignored (since there might not be an old one)
