### PR TITLE
docs: fix finetuner links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ recall@5 0.0573470744680851
 
 More metrics can be used such as `precision_at_k`, `ndcg_at_k`, `hit_at_k`.
 
-If you think a pretrained ResNet50 is good enough, let me tell you with [Finetuner](https://github.com/jina-ai/finetuner) you could do much better in just 10 extra lines of code. [Here is how](https://finetuner.jina.ai/tasks/image-to-image/).
+If you think a pretrained ResNet50 is good enough, let me tell you with [Finetuner](https://github.com/jina-ai/finetuner) you could do much better in just 10 extra lines of code. [Here is how](https://finetuner.jina.ai/notebooks/image_to_image/).
 
 
 ### Save results


### PR DESCRIPTION
in the last documentation refine, we embeded three Jupyter notebooks in to finetuner documentation and the image-to-image links being updated.
