### PR TITLE
fix(redis): convert score of search results to float

### DIFF
--- a/docarray/array/storage/redis/find.py
+++ b/docarray/array/storage/redis/find.py
@@ -66,7 +66,7 @@ class FindMixin(BaseFindMixin):
         da = DocumentArray()
         for res in results:
             doc = Document.from_base64(res.blob.encode())
-            doc.scores['score'] = NamedScore(value=res.vector_score)
+            doc.scores['score'] = NamedScore(float(value=res.vector_score))
             da.append(doc)
         return da
 

--- a/docarray/array/storage/redis/find.py
+++ b/docarray/array/storage/redis/find.py
@@ -66,7 +66,7 @@ class FindMixin(BaseFindMixin):
         da = DocumentArray()
         for res in results:
             doc = Document.from_base64(res.blob.encode())
-            doc.scores['score'] = NamedScore(float(value=res.vector_score))
+            doc.scores['score'] = NamedScore(value=float(res.vector_score))
             da.append(doc)
         return da
 

--- a/tests/unit/array/mixins/test_match.py
+++ b/tests/unit/array/mixins/test_match.py
@@ -614,12 +614,12 @@ numeric_operators_qdrant = {
 }
 
 numeric_operators_redis = {
-    '$gte': operator.ge,
-    '$gt': operator.gt,
-    '$lte': operator.le,
-    '$lt': operator.lt,
-    '$eq': operator.eq,
-    '$ne': operator.ne,
+    'gte': operator.ge,
+    'gt': operator.gt,
+    'lte': operator.le,
+    'lt': operator.lt,
+    'eq': operator.eq,
+    'ne': operator.ne,
 }
 
 
@@ -686,15 +686,42 @@ numeric_operators_redis = {
             for operator in numeric_operators_annlite.keys()
         ],
         *[
-            tuple(
-                [
-                    'redis',
-                    lambda operator, threshold: {'price': {operator: threshold}},
-                    numeric_operators_redis,
-                    operator,
-                ]
-            )
-            for operator in numeric_operators_redis.keys()
+            (
+                'redis',
+                lambda operator, threshold: f'@price:[{threshold} inf] ',
+                numeric_operators_redis,
+                'gte',
+            ),
+            (
+                'redis',
+                lambda operator, threshold: f'@price:[({threshold} inf] ',
+                numeric_operators_redis,
+                'gt',
+            ),
+            (
+                'redis',
+                lambda operator, threshold: f'@price:[-inf {threshold}] ',
+                numeric_operators_redis,
+                'lte',
+            ),
+            (
+                'redis',
+                lambda operator, threshold: f'@price:[-inf ({threshold}] ',
+                numeric_operators_redis,
+                'lt',
+            ),
+            (
+                'redis',
+                lambda operator, threshold: f'@price:[{threshold} {threshold}] ',
+                numeric_operators_redis,
+                'eq',
+            ),
+            (
+                'redis',
+                lambda operator, threshold: f'(- @price:[{threshold} {threshold}]) ',
+                numeric_operators_redis,
+                'ne',
+            ),
         ],
     ],
 )


### PR DESCRIPTION
The type of Redis search result score `res.vector_score` is String. This should be converted to `float`.

Goal:

- [x] convert score to `float`
- [x] update Redis QL in `test_match`