### PR TITLE
feat: add 3d data handling of mesh vertices and faces

### DIFF
--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -40,3 +40,28 @@ class MeshDataMixin:
             self.tensor = np.array(mesh.sample(samples))
 
         return self
+
+    def load_uri_to_vertices_and_faces_chunk_tensors(self: 'T') -> 'T':
+        """Convert a 3d mesh-like :attr:`.uri` into :attr:`.chunks` as vertices and faces
+
+        :return: itself after processed
+        """
+
+        import trimesh
+        import urllib.parse
+        from docarray.document import Document
+
+        scheme = urllib.parse.urlparse(self.uri).scheme
+        loader = trimesh.load_remote if scheme in ['http', 'https'] else trimesh.load
+
+        mesh = loader(self.uri, force='mesh')
+
+        vertices = mesh.vertices.view(np.ndarray)
+        faces = mesh.faces.view(np.ndarray)
+
+        self.chunks = [
+            Document(name='vertices', tensor=vertices),
+            Document(name='faces', tensor=faces),
+        ]
+
+        return self

--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -63,5 +64,34 @@ class MeshDataMixin:
             Document(name='vertices', tensor=vertices),
             Document(name='faces', tensor=faces),
         ]
+
+        return self
+
+    def load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(
+        self: 'T', samples: int
+    ) -> 'T':
+        """Convert a 3d mesh of vertices and faces from :attr:`.chunks` into point cloud :attr:`.tensor`
+
+        :param samples: number of points to sample from the mesh
+        :return: itself after processed
+        """
+        import trimesh
+
+        vertices = None
+        faces = None
+
+        for chunk in self.chunks:
+            if chunk.tags['name'] == 'vertices':
+                vertices = chunk.tensor
+            if chunk.tags['name'] == 'faces':
+                faces = chunk.tensor
+
+        if vertices is not None and faces is not None:
+            mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+            self.tensor = np.array(mesh.sample(samples))
+        else:
+            warnings.warn(
+                'Point cloud tensor can not be set, since vertices and faces chunk tensor have not been set.'
+            )
 
         return self

--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -90,7 +90,7 @@ class MeshDataMixin:
             mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
             self.tensor = np.array(mesh.sample(samples))
         else:
-            warnings.warn(
+            raise AttributeError(
                 'Point cloud tensor can not be set, since vertices and faces chunk tensor have not been set.'
             )
 

--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -42,7 +42,7 @@ class MeshDataMixin:
 
         return self
 
-    def load_uri_to_vertices_and_faces_chunk_tensors(self: 'T') -> 'T':
+    def load_uri_to_vertices_and_faces(self: 'T') -> 'T':
         """Convert a 3d mesh-like :attr:`.uri` into :attr:`.chunks` as vertices and faces
 
         :return: itself after processed
@@ -67,9 +67,7 @@ class MeshDataMixin:
 
         return self
 
-    def load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(
-        self: 'T', samples: int
-    ) -> 'T':
+    def load_vertices_and_faces_to_point_cloud(self: 'T', samples: int) -> 'T':
         """Convert a 3d mesh of vertices and faces from :attr:`.chunks` into point cloud :attr:`.tensor`
 
         :param samples: number of points to sample from the mesh

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -65,8 +65,3 @@ for chunk in doc.chunks:
 chunk.tags = {'name': 'vertices'}
 chunk.tags = {'name': 'faces'}
 ```
-The following pictures depict a 3D mesh. 
-
-```{figure} 3dmesh-man.gif
-:width: 50%
-```

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -48,12 +48,12 @@ The following picture depicts a 3D mesh:
 
 ## Point cloud representation
 
-A point cloud is a representation of a 3D mesh. It is made by repeatedly and uniformly sampling points within the 3D body. Compared to the mesh representation, the point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud via:
+A point cloud is a representation of a 3D mesh. It is made by repeatedly and uniformly sampling points within the 3D body. Compared to the mesh representation, the point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud of size `samples` via:
 
 ```python
 from docarray import Document
 
-doc = Document(uri='viking.glb').load_uri_to_point_cloud_tensor(1000)
+doc = Document(uri='viking.glb').load_uri_to_point_cloud_tensor(samples=1000)
 
 print(doc.tensor.shape)
 ```

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -7,35 +7,9 @@ This feature requires `trimesh`. You can install it via `pip install "docarray[f
 
 A 3D mesh is the structural build of a 3D model consisting of polygons. Most 3D meshes are created via professional software packages, such as commercial suites like Unity, or the free open source Blender 3D.
 
-## Point cloud
+## Vertices and faces representation 
 
-Point cloud is a representation of a 3D mesh. It is made by repeated and uniformly sampling points within the 3D body. Comparing to the mesh representation, point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud via:
-
-```python
-from docarray import Document
-
-doc = Document(uri='viking.glb').load_uri_to_point_cloud_tensor(1000)
-
-print(doc.tensor.shape)
-```
-
-```text
-(1000, 3)
-```
-
-The following pictures depict a 3D mesh and a point cloud with 1000 samples from that 3D mesh. 
-
-```{figure} 3dmesh-man.gif
-:width: 50%
-```
-
-```{figure} pointcloud-man.gif
-:width: 50%
-```
-
-## Mesh
-
-A mesh is a representation of a 3D object and consists of vertices and faces. Vertices are points in a 3D space, represented as a tensor of shape (n_points, 3). Faces are triangular surfaces that can be defined by three points in 3D space, corresponding to the three vertices of a triangle. Faces can be represented as a tensor of shape (n_faces, 3). Each number in that tensor refers to an index of a vertex in the tensor of vertices.
+A 3D mesh can be represented by its vertices and faces. Vertices are points in a 3D space, represented as a tensor of shape (n_points, 3). Faces are triangular surfaces that can be defined by three points in 3D space, corresponding to the three vertices of a triangle. Faces can be represented as a tensor of shape (n_faces, 3). Each number in that tensor refers to an index of a vertex in the tensor of vertices.
 
 In DocArray, you can load a mesh and save its vertices and faces to a Documents `.chunks` as follows:
 
@@ -64,4 +38,32 @@ for chunk in doc.chunks:
 ```text
 chunk.tags = {'name': 'vertices'}
 chunk.tags = {'name': 'faces'}
+```
+
+The following picture depicts a 3D mesh:
+
+```{figure} 3dmesh-man.gif
+:width: 50%
+```
+
+## Point cloud representation
+
+Point cloud is a representation of a 3D mesh. It is made by repeated and uniformly sampling points within the 3D body. Comparing to the mesh representation, point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud via:
+
+```python
+from docarray import Document
+
+doc = Document(uri='viking.glb').load_uri_to_point_cloud_tensor(1000)
+
+print(doc.tensor.shape)
+```
+
+```text
+(1000, 3)
+```
+
+The following picture depicts a point cloud with 1000 samples from the previously depicted 3D mesh.
+
+```{figure} pointcloud-man.gif
+:width: 50%
 ```

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -13,6 +13,7 @@ Point cloud is a representation of a 3D mesh. It is made by repeated and uniform
 
 ```python
 from docarray import Document
+
 doc = Document(uri='viking.glb').load_uri_to_point_cloud_tensor(1000)
 
 print(doc.tensor.shape)
@@ -29,5 +30,43 @@ The following pictures depict a 3D mesh and a point cloud with 1000 samples from
 ```
 
 ```{figure} pointcloud-man.gif
+:width: 50%
+```
+
+## Mesh
+
+A mesh is a representation of a 3D object and consists of vertices and faces. Vertices are points in a 3D space, represented as a tensor of shape (n_points, 3). Faces are triangular surfaces that can be defined by three points in 3D space, corresponding to the three vertices of a triangle. Faces can be represented as a tensor of shape (n_faces, 3). Each number in that tensor refers to an index of a vertex in the tensor of vertices.
+
+In DocArray, you can load a mesh and save its vertices and faces to a Documents `.chunks` as follows:
+
+```python
+from docarray import Document
+
+doc = Document(uri='viking.glb').load_uri_to_vertices_and_faces()
+
+doc.summary()
+```
+
+```text
+ <Document ('id', 'chunks') at 7f907d786d6c11ec840a1e008a366d49>
+    └─ chunks
+          ├─ <Document ('id', 'parent_id', 'granularity', 'tensor', 'tags') at 7f907ab26d6c11ec840a1e008a366d49>
+          └─ <Document ('id', 'parent_id', 'granularity', 'tensor', 'tags') at 7f907c106d6c11ec840a1e008a366d49>
+```
+
+This stores the vertices and faces in `.tensor` of two separate sub-Documents in a Documents `.chunks`. Both sub-Documents have a name assigned to them ('vertices' or 'faces''), which is saved in `.tags`:
+
+```python
+for chunk in doc.chunks:
+    print(f'chunk.tags = {chunk.tags}')
+```
+
+```text
+chunk.tags = {'name': 'vertices'}
+chunk.tags = {'name': 'faces'}
+```
+The following pictures depict a 3D mesh. 
+
+```{figure} 3dmesh-man.gif
 :width: 50%
 ```

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -11,7 +11,7 @@ A 3D mesh is the structural build of a 3D model consisting of polygons. Most 3D 
 
 A 3D mesh can be represented by its vertices and faces. Vertices are points in a 3D space, represented as a tensor of shape (n_points, 3). Faces are triangular surfaces that can be defined by three points in 3D space, corresponding to the three vertices of a triangle. Faces can be represented as a tensor of shape (n_faces, 3). Each number in that tensor refers to an index of a vertex in the tensor of vertices.
 
-In DocArray, you can load a mesh and save its vertices and faces to a Documents `.chunks` as follows:
+In DocArray, you can load a mesh and save its vertices and faces to a Document's `.chunks` as follows:
 
 ```python
 from docarray import Document
@@ -28,7 +28,7 @@ doc.summary()
           └─ <Document ('id', 'parent_id', 'granularity', 'tensor', 'tags') at 7f907c106d6c11ec840a1e008a366d49>
 ```
 
-This stores the vertices and faces in `.tensor` of two separate sub-Documents in a Documents `.chunks`. Both sub-Documents have a name assigned to them ('vertices' or 'faces''), which is saved in `.tags`:
+This stores the vertices and faces in `.tensor` of two separate sub-Documents in a Document's `.chunks`. Each sub-Document has a name assigned to it ('vertices' or 'faces'), which is saved in `.tags`:
 
 ```python
 for chunk in doc.chunks:
@@ -48,7 +48,7 @@ The following picture depicts a 3D mesh:
 
 ## Point cloud representation
 
-Point cloud is a representation of a 3D mesh. It is made by repeated and uniformly sampling points within the 3D body. Comparing to the mesh representation, point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud via:
+A point cloud is a representation of a 3D mesh. It is made by repeatedly and uniformly sampling points within the 3D body. Compared to the mesh representation, the point cloud is a fixed size ndarray and hence easier for deep learning algorithms to handle. In DocArray, you can simply load a 3D mesh and convert it into a point cloud via:
 
 ```python
 from docarray import Document

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -279,7 +279,7 @@ def test_glb_converters(uri, chunk_num):
 @pytest.mark.parametrize('uri', [(os.path.join(cur_dir, 'toydata/test.glb'))])
 def test_load_uri_to_vertices_and_faces(uri):
     doc = Document(uri=uri)
-    doc.load_uri_to_vertices_and_faces_chunk_tensors()
+    doc.load_uri_to_vertices_and_faces()
 
     assert len(doc.chunks) == 2
     assert doc.chunks[0].tags['name'] == 'vertices'
@@ -289,10 +289,10 @@ def test_load_uri_to_vertices_and_faces(uri):
 
 
 @pytest.mark.parametrize('uri', [(os.path.join(cur_dir, 'toydata/test.glb'))])
-def test_load_vertices_and_faces_chunk_tensor_to_point_cloud(uri):
+def test_load_vertices_and_faces_to_point_cloud(uri):
     doc = Document(uri=uri)
-    doc.load_uri_to_vertices_and_faces_chunk_tensors()
-    doc.load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(100)
+    doc.load_uri_to_vertices_and_faces()
+    doc.load_vertices_and_faces_to_point_cloud(100)
 
     assert doc.tensor.shape == (100, 3)
     assert isinstance(doc.tensor, np.ndarray)
@@ -305,4 +305,4 @@ def test_load_to_point_cloud_without_vertices_faces_set_raise_warning(uri):
     with pytest.raises(
         AttributeError, match='vertices and faces chunk tensor have not been set'
     ):
-        doc.load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(100)
+        doc.load_vertices_and_faces_to_point_cloud(100)

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -286,3 +286,23 @@ def test_load_uri_to_vertices_and_faces(uri):
     assert doc.chunks[0].tensor.shape[1] == 3
     assert doc.chunks[1].tags['name'] == 'faces'
     assert doc.chunks[1].tensor.shape[1] == 3
+
+
+@pytest.mark.parametrize('uri', [(os.path.join(cur_dir, 'toydata/test.glb'))])
+def test_load_vertices_and_faces_chunk_tensor_to_point_cloud(uri):
+    doc = Document(uri=uri)
+    doc.load_uri_to_vertices_and_faces_chunk_tensors()
+    doc.load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(100)
+
+    assert doc.tensor.shape == (100, 3)
+    assert isinstance(doc.tensor, np.ndarray)
+
+
+@pytest.mark.parametrize('uri', [(os.path.join(cur_dir, 'toydata/test.glb'))])
+def test_load_to_point_cloud_without_vertices_faces_set_raise_warning(uri):
+    doc = Document(uri=uri)
+
+    with pytest.warns(
+        UserWarning, match='vertices and faces chunk tensor have not been set'
+    ):
+        doc.load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(100)

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -274,3 +274,15 @@ def test_glb_converters(uri, chunk_num):
     doc.load_uri_to_point_cloud_tensor(2000, as_chunks=True)
     assert len(doc.chunks) == chunk_num
     assert doc.chunks[0].tensor.shape == (2000, 3)
+
+
+@pytest.mark.parametrize('uri', [(os.path.join(cur_dir, 'toydata/test.glb'))])
+def test_load_uri_to_vertices_and_faces(uri):
+    doc = Document(uri=uri)
+    doc.load_uri_to_vertices_and_faces_chunk_tensors()
+
+    assert len(doc.chunks) == 2
+    assert doc.chunks[0].tags['name'] == 'vertices'
+    assert doc.chunks[0].tensor.shape[1] == 3
+    assert doc.chunks[1].tags['name'] == 'faces'
+    assert doc.chunks[1].tensor.shape[1] == 3

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -302,7 +302,7 @@ def test_load_vertices_and_faces_chunk_tensor_to_point_cloud(uri):
 def test_load_to_point_cloud_without_vertices_faces_set_raise_warning(uri):
     doc = Document(uri=uri)
 
-    with pytest.warns(
-        UserWarning, match='vertices and faces chunk tensor have not been set'
+    with pytest.raises(
+        AttributeError, match='vertices and faces chunk tensor have not been set'
     ):
         doc.load_vertices_and_faces_chunk_tensors_to_point_cloud_tensor(100)


### PR DESCRIPTION
Goals:

- Currently, DocArray only supports point clouds for 3d data representation. 
- We want to add functions to additionally support 3d data representation of meshes, which include more information about a 3d object than a point cloud, and seem to be more commonly used. Meshes basically consist of a vertices tensor and a faces tensor, which I plan to load to load to chunks, i.e.:

```python
from docarray import Document

doc = Document(uri='some/uri')
doc.load_uri_to_vertices_and_faces_tensors()

# resulting in:
# doc = Document(
#     uri='some/uri', 
#     chunks=[
#         Document(name='vertices', tensor=sometensor), 
#         Document(name='faces', tensor=sometensor)
#     ]
# )
```

- [x] add `load_uri_to_vertices_and_faces_chunk_tensors`  + tests
- [x] load vertices+faces to point cloud
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
