### PR TITLE
docs: remove swearing #686

### DIFF
--- a/docs/fundamentals/fastapi-support/index.md
+++ b/docs/fundamentals/fastapi-support/index.md
@@ -1,28 +1,27 @@
 (fastapi-support)=
 # FastAPI/Pydantic
 
-Long story short, DocArray supports [pydantic data model](https://pydantic-docs.helpmanual.io/) via {class}`~docarray.document.pydantic_model.PydanticDocument` and {class}`~docarray.document.pydantic_model.PydanticDocumentArray`.
+DocArray supports the [pydantic data model](https://pydantic-docs.helpmanual.io/) via {class}`~docarray.document.pydantic_model.PydanticDocument` and {class}`~docarray.document.pydantic_model.PydanticDocumentArray`.
+Let's take a look at what this means.
 
-But this is probably too short to make any sense. So let's take a step back and see what does this mean.
+When you want to send or receive Document or DocumentArray objects via the REST API, you can use `.from_json`/`.to_json` to convert the Document or DocumentArray object into JSON. This has been introduced in the {ref}`docarray-serialization` section.
 
-When you want to send/receive Document or DocumentArray object via REST API, you can use `.from_json`/`.to_json` that convert the Document/DocumentArray object into JSON. This has been introduced in the {ref}`docarray-serialization` section.
+This method, although quite intuitive to many data scientists, is *not* the modern way of building API services. Your engineer friends won't be happy if you give them a service like this. The main problem is **data validation**.
 
-This way, although quite intuitive to many data scientists, is *not* the modern way of building API services. Your engineer friends won't be happy if you give them a service like this. The main problem here is the **data validation**.
+Of course, you can include data validation in your service logic, but this can be difficult as you will need to check field by field and repeat things like `isinstance(field, int)`, not to mention handling nested JSON.
 
-Of course, you can include data validation inside your service logic, but it is often brainfuck as you will need to check field by field and repeat things like `isinstance(field, int)`, not even to mention handling nested JSON.
+Modern web frameworks validate the data _before_ it enters the core logic. For example, [FastAPI](https://fastapi.tiangolo.com/) leverages [pydantic](https://pydantic-docs.helpmanual.io/) to validate input and output data.
 
-Modern web frameworks validate the data _before_ it enters the core logic. For example, [FastAPI](https://fastapi.tiangolo.com/) leverages [pydantic](https://pydantic-docs.helpmanual.io/) to validate input & output data.
-
-This chapter will introduce how to leverage DocArray's pydantic support in a FastAPI service to build a modern API service. The fundamentals of FastAPI can be learned from its docs. I won't repeat them here again.
+This chapter will introduce how to use DocArray's pydantic support in a FastAPI service to build a modern API service. The fundamentals of FastAPI can be learned from its docs. I won't repeat them here again.
 
 ```{tip}
-Features introduced in this chapter require `fastapi` and `pydantic` as dependency, please do `pip install "docarray[full]"` to enable it.
+Features introduced in this chapter require `fastapi` and `pydantic` as dependencies. Please run `pip install "docarray[full]"` to enable it.
 ```
 
 (schema-gen)=
 ## JSON Schema
 
-You can get [JSON Schema](https://json-schema.org/) (OpenAPI itself is based on JSON Schema) of Document and DocumentArray by {meth}`~docarray.array.mixins.pydantic.PydanticMixin.get_json_schema`.
+You can get the [JSON Schema](https://json-schema.org/) (OpenAPI itself is based on JSON Schema) of a Document or DocumentArray using the {meth}`~docarray.array.mixins.pydantic.PydanticMixin.get_json_schema` method.
 
 ````{tab} Document
 ```python
@@ -67,10 +66,10 @@ DocumentArray.get_json_schema()
 ```
 ````
 
-Give them to your engineer friends, they will be happy as now they can understand what data format you are working with. These schemas also help them to easily integrate DocArray into any webservice.
+When you give this schema to your engineer friends, they'll be able to understand the data format you're working with. These schemas also help them to easily integrate DocArray into any webservice.
 
 
-## Validate incoming Document and DocumentArray
+## Validate incoming Document and DocumentArray objects
 
 You can import {class}`~docarray.document.pydantic_model.PydanticDocument` and {class}`~docarray.document.pydantic_model.PydanticDocumentArray` pydantic data models, and use them to type hint your endpoint. This will enable the data validation.
 
@@ -110,7 +109,7 @@ Both got rejected (422 error) as they are not valid.
 
 ## Convert between pydantic model and DocArray objects
 
-{class}`~docarray.document.pydantic_model.PydanticDocument` and {class}`~docarray.document.pydantic_model.PydanticDocumentArray` are mainly for data validation. When you want to implement real logics, you need to convert it into Document or DocumentArray. This can be easily achieved via {meth}`~docarray.array.mixins.pydantic.PydanticMixin.from_pydantic_model`. When you are done with processing and want to send back, you can call {meth}`~docarray.array.mixins.pydantic.PydanticMixin.to_pydantic_model`.
+{class}`~docarray.document.pydantic_model.PydanticDocument` and {class}`~docarray.document.pydantic_model.PydanticDocumentArray` are mainly for data validation. When you want to implement real logic, you need to convert them into a Document or DocumentArray. This can be easily achieved via the {meth}`~docarray.array.mixins.pydantic.PydanticMixin.from_pydantic_model` method. When you are done with processing and want to send a {class}`~docarray.document.pydantic_model.PydanticDocument` back, you can call {meth}`~docarray.array.mixins.pydantic.PydanticMixin.to_pydantic_model`.
 
 In a nutshell, the whole procedure looks like the following:
 
@@ -118,7 +117,7 @@ In a nutshell, the whole procedure looks like the following:
 ```
 
 
-Let's see an example,
+Let's see an example:
 
 ```python
 from docarray import Document, DocumentArray
@@ -143,9 +142,9 @@ async def create_array(items: PydanticDocumentArray):
 
 ## Limit returned fields by response model
 
-Supporting pydantic data model means much more beyond data validation. One useful pattern is to define a smaller data model and restrict the response to certain fields of the Document.
+Supporting the pydantic data model means much more than data validation. One useful pattern is to define a smaller data model and restrict the response to certain fields of the Document.
 
-Imagine we have a DocumentArray with `.embeddings` on the server side. But we do not want to return them to the client for some reasons (1. meaningless to users; 2. too big to transfer). One can simply define the interested fields via 
+Imagine we have a DocumentArray with `.embeddings` on the server side, but we do not want to return them to the client for various reasons (for example, they may be meaningless to users, or too big to transfer). One can simply define the fields of interest via 
  `pydantic.BaseModel` and then use it in `response_model=`.
 
 ```python
@@ -169,7 +168,7 @@ And you get:
 
 ## Limit returned results recursively
 
-The same idea applies to DocumentArray as well. Say after [`.match()`](../documentarray/matching.md), you are only interested in `.id` - the parent `.id` and all matches `id`. You can declare a `BaseModel` as follows:
+The same idea applies to DocumentArray as well. Say after [`.match()`](../documentarray/matching.md), you are only interested in `.id`—the parent `.id` and the `.id`s of all matches. You can declare a `BaseModel` as follows:
 
 ```python
 from typing import List, Optional
@@ -191,7 +190,7 @@ async def get_match_id_only():
     return da.to_pydantic_model()
 ```
 
-Then you get a very nice result of `id`s of matches (potentially unlimited depth). 
+Then you get a very nice result containing `id`s of matches (of potentially unlimited depth). 
 
 ```text
 [{'id': 'ef82e4f4756411ecb2c01e008a366d49',
@@ -202,14 +201,15 @@ Then you get a very nice result of `id`s of matches (potentially unlimited depth
               ...
 ```
 
-If `'matches': None` is annoying to you (they are here because you didn't compute second-degree matches), you can further leverage FastAPI's feature and do:
+If `'matches': None` is annoying to you (they are here because you didn't compute second-degree matches), you can further leverage FastAPI's features and do:
+
 ```python
 @app.get('/get_match', response_model=List[IdMatch], response_model_exclude_none=True)
 async def get_match_id_only():
     ...
 ```
 
-Finally, you get a very clean results with ids and matches only:
+Finally, you get a very clean result with `id`s and matches only:
 
 ```text
 [{'id': '3da6383e756511ecb7cb1e008a366d49',
@@ -229,4 +229,4 @@ Finally, you get a very clean results with ids and matches only:
               ...
 ```
 
-More tricks and usages of pydantic model can be found in its docs. Same for FastAPI. I strongly recommend interested readers to go through their documentations. 
+For more information about [pydantic](https://pydantic-docs.helpmanual.io/) and [FastAPI](https://fastapi.tiangolo.com/), we strongly recommend reading their documentation.


### PR DESCRIPTION
Goals:

- Remove swearing from FastAPI/Pydantic page
- Fix some grammar and awkward wording on the same page