### PR TITLE
chore: move setup requirements to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=18.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     long_description=_long_description,
     long_description_content_type='text/markdown',
     zip_safe=False,
-    setup_requires=['setuptools>=18.0', 'wheel'],
     install_requires=['numpy', 'rich>=12.0.0', 'jina-hubble-sdk>=0.13.1'],
     extras_require={
         # req usage, please see https://docarray.jina.ai/#install


### PR DESCRIPTION
Goals:
- Get pip to properly pick up this distributions setup requirements
- A similar issue was in jina repo: https://github.com/jina-ai/jina/issues/5346
